### PR TITLE
feat(frontend): add Audit Logs and Routing Rules pages

### DIFF
--- a/web-ui/src/components/Sidebar.tsx
+++ b/web-ui/src/components/Sidebar.tsx
@@ -8,13 +8,17 @@ import {
   Users,
   BarChart3,
   Settings,
-  Gauge
+  Gauge,
+  Route,
+  ClipboardList,
 } from 'lucide-react'
+import { useAuthStore } from '../stores/auth'
 
-const navItems = [
+const baseNavItems = [
   { path: '/', label: 'Dashboard', icon: LayoutDashboard },
   { path: '/instances', label: 'Instances', icon: Server },
   { path: '/firewall', label: 'Firewall', icon: Shield },
+  { path: '/routing', label: 'Routing', icon: Route },
   { path: '/traffic', label: 'Traffic Shaping', icon: Gauge },
   { path: '/vpn', label: 'VPN', icon: Network },
   { path: '/mail', label: 'Mail', icon: Mail },
@@ -24,6 +28,14 @@ const navItems = [
 ]
 
 export function Sidebar() {
+  const { user } = useAuthStore()
+  const isAdmin = user?.role === 'admin' || user?.role === 'superadmin'
+
+  const navItems = [
+    ...baseNavItems,
+    ...(isAdmin ? [{ path: '/audit', label: 'Audit Logs', icon: ClipboardList }] : []),
+  ]
+
   return (
     <aside className="w-64 bg-white border-r border-gray-200 min-h-[calc(100vh-73px)]">
       <nav className="p-4">

--- a/web-ui/src/hooks/useApi.ts
+++ b/web-ui/src/hooks/useApi.ts
@@ -43,6 +43,9 @@ import type {
   MetricsQuery,
   MetricsSummary,
   DashboardData,
+  RoutingRule,
+  RoutingRuleCreate,
+  RoutingRuleUpdate,
 } from '../types'
 
 const queryKeys = {
@@ -65,6 +68,7 @@ const queryKeys = {
   metricsSummary: (params?: Record<string, unknown>) => ['metrics', 'summary', params] as const,
   dashboardData: (instanceId: number) => ['dashboard', instanceId] as const,
   metricsOverview: ['metrics', 'overview'] as const,
+  routingRules: (instanceId: number) => ['routing-rules', instanceId] as const,
 }
 
 export { queryKeys }
@@ -655,5 +659,69 @@ export function useMetricsOverview(options?: Partial<UseQueryOptions<MetricsOver
       return data
     },
     ...options,
+  })
+}
+
+// Routing hooks
+export function useRoutingRules(instanceId: number, options?: Partial<UseQueryOptions<RoutingRule[]>>) {
+  return useQuery<RoutingRule[]>({
+    queryKey: queryKeys.routingRules(instanceId),
+    queryFn: async () => {
+      const { data } = await api.get(`/routing/rules/${instanceId}`)
+      return data
+    },
+    enabled: instanceId > 0,
+    ...options,
+  })
+}
+
+export function useCreateRoutingRule(instanceId: number) {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: async (rule: RoutingRuleCreate) => {
+      const { data } = await api.post(`/routing/rules/${instanceId}`, rule)
+      return data as RoutingRule
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.routingRules(instanceId) })
+    },
+  })
+}
+
+export function useUpdateRoutingRule(instanceId: number) {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: async ({ id, ...rule }: { id: number } & RoutingRuleUpdate) => {
+      const { data } = await api.patch(`/routing/rules/${id}`, rule)
+      return data as RoutingRule
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.routingRules(instanceId) })
+    },
+  })
+}
+
+export function useDeleteRoutingRule(instanceId: number) {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: async (id: number) => {
+      await api.delete(`/routing/rules/${id}`)
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.routingRules(instanceId) })
+    },
+  })
+}
+
+export function useApplyRouting(instanceId: number) {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: async () => {
+      const { data } = await api.post(`/routing/apply/${instanceId}`)
+      return data
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.routingRules(instanceId) })
+    },
   })
 }

--- a/web-ui/src/pages/AuditLogs.tsx
+++ b/web-ui/src/pages/AuditLogs.tsx
@@ -1,0 +1,171 @@
+import { useState } from 'react'
+import { ClipboardList, Filter, RefreshCw } from 'lucide-react'
+import { useAuditLogs } from '../hooks/useApi'
+import { useAuthStore } from '../stores/auth'
+import {
+  DataTable,
+  LoadingSpinner,
+  EmptyState,
+} from '../components/ui'
+import { formatDistanceToNow } from 'date-fns'
+import type { AuditLog } from '../types'
+
+const actionColors: Record<string, string> = {
+  create: 'bg-green-100 text-green-700',
+  update: 'bg-blue-100 text-blue-700',
+  delete: 'bg-red-100 text-red-700',
+  deploy: 'bg-purple-100 text-purple-700',
+  login: 'bg-gray-100 text-gray-700',
+}
+
+export function AuditLogs() {
+  const { user } = useAuthStore()
+  const isAdmin = user?.role === 'admin' || user?.role === 'superadmin'
+
+  const [filters, setFilters] = useState({
+    action: '',
+    resource_type: '',
+    limit: 50,
+  })
+
+  const params: Record<string, unknown> = { limit: filters.limit }
+  if (filters.action) params.action = filters.action
+  if (filters.resource_type) params.resource_type = filters.resource_type
+
+  const { data: logs, isLoading, refetch } = useAuditLogs(params)
+
+  if (!isAdmin) {
+    return (
+      <div>
+        <h2 className="text-2xl font-bold text-gray-900 mb-6">Audit Logs</h2>
+        <EmptyState
+          icon={ClipboardList}
+          title="Access Denied"
+          description="You need admin privileges to view audit logs."
+        />
+      </div>
+    )
+  }
+
+  if (isLoading) return <LoadingSpinner />
+
+  const columns = [
+    {
+      key: 'timestamp',
+      header: 'Time',
+      render: (log: AuditLog) => (
+        <span className="text-sm text-gray-600 whitespace-nowrap">
+          {formatDistanceToNow(new Date(log.timestamp), { addSuffix: true })}
+        </span>
+      ),
+    },
+    {
+      key: 'action',
+      header: 'Action',
+      render: (log: AuditLog) => (
+        <span className={`px-2 py-0.5 rounded text-xs font-medium capitalize ${actionColors[log.action] || 'bg-gray-100 text-gray-700'}`}>
+          {log.action}
+        </span>
+      ),
+    },
+    {
+      key: 'resource',
+      header: 'Resource',
+      render: (log: AuditLog) => (
+        <div>
+          <span className="text-sm font-medium text-gray-900">{log.resource_type}</span>
+          {log.resource_id && (
+            <span className="text-xs text-gray-500 ml-1">#{log.resource_id}</span>
+          )}
+        </div>
+      ),
+    },
+    {
+      key: 'user',
+      header: 'User',
+      render: (log: AuditLog) => (
+        <span className="text-sm text-gray-600">
+          {log.user_id ? `User #${log.user_id}` : 'System'}
+        </span>
+      ),
+    },
+    {
+      key: 'instance',
+      header: 'Instance',
+      render: (log: AuditLog) => (
+        <span className="text-sm text-gray-600">
+          {log.instance_id ? `#${log.instance_id}` : '-'}
+        </span>
+      ),
+    },
+    {
+      key: 'ip',
+      header: 'IP Address',
+      render: (log: AuditLog) => (
+        <span className="text-sm text-gray-500 font-mono">{log.ip_address || '-'}</span>
+      ),
+    },
+  ]
+
+  return (
+    <div>
+      <div className="flex items-center justify-between mb-6">
+        <h2 className="text-2xl font-bold text-gray-900">Audit Logs</h2>
+        <div className="flex items-center gap-2">
+          <button
+            onClick={() => refetch()}
+            className="flex items-center gap-2 px-3 py-2 bg-white border border-gray-200 text-gray-700 rounded-lg hover:bg-gray-50 text-sm"
+          >
+            <RefreshCw className="w-4 h-4" />
+            Refresh
+          </button>
+        </div>
+      </div>
+
+      {/* Filters */}
+      <div className="bg-white p-4 rounded-lg shadow-sm border border-gray-200 mb-6">
+        <div className="flex items-center gap-4">
+          <Filter className="w-4 h-4 text-gray-400" />
+          <select
+            value={filters.action}
+            onChange={(e) => setFilters({ ...filters, action: e.target.value })}
+            className="px-3 py-1.5 border border-gray-200 rounded-lg text-sm"
+          >
+            <option value="">All Actions</option>
+            <option value="create">Create</option>
+            <option value="update">Update</option>
+            <option value="delete">Delete</option>
+            <option value="deploy">Deploy</option>
+            <option value="login">Login</option>
+          </select>
+          <select
+            value={filters.resource_type}
+            onChange={(e) => setFilters({ ...filters, resource_type: e.target.value })}
+            className="px-3 py-1.5 border border-gray-200 rounded-lg text-sm"
+          >
+            <option value="">All Resources</option>
+            <option value="firewall_rule">Firewall Rule</option>
+            <option value="instance">Instance</option>
+            <option value="user">User</option>
+            <option value="mail_domain">Mail Domain</option>
+            <option value="vpn_server">VPN Server</option>
+            <option value="routing_rule">Routing Rule</option>
+          </select>
+        </div>
+      </div>
+
+      <DataTable
+        columns={columns}
+        data={logs || []}
+        keyExtractor={(log) => log.id}
+        emptyContent={
+          <EmptyState
+            icon={ClipboardList}
+            title="No Audit Logs"
+            description="Audit logs will appear here once actions are performed."
+          />
+        }
+      />
+    </div>
+  )
+}

--- a/web-ui/src/pages/RoutingRules.tsx
+++ b/web-ui/src/pages/RoutingRules.tsx
@@ -1,0 +1,373 @@
+import { useState } from 'react'
+import { Plus, Route, Upload, ArrowUp, ArrowDown } from 'lucide-react'
+import { useInstanceStore } from '../stores/instance'
+import {
+  useRoutingRules,
+  useCreateRoutingRule,
+  useUpdateRoutingRule,
+  useDeleteRoutingRule,
+  useApplyRouting,
+} from '../hooks/useApi'
+import {
+  InstanceSelector,
+  DataTable,
+  Modal,
+  ConfirmDialog,
+  EmptyState,
+  LoadingSpinner,
+} from '../components/ui'
+import type { RoutingRule, RoutingRuleCreate, RoutingRuleUpdate } from '../types'
+
+export function RoutingRules() {
+  const { selectedInstanceId } = useInstanceStore()
+  const { data: rules, isLoading } = useRoutingRules(selectedInstanceId!)
+  const createMutation = useCreateRoutingRule(selectedInstanceId!)
+  const updateMutation = useUpdateRoutingRule(selectedInstanceId!)
+  const deleteMutation = useDeleteRoutingRule(selectedInstanceId!)
+  const applyMutation = useApplyRouting(selectedInstanceId!)
+
+  const [showCreate, setShowCreate] = useState(false)
+  const [editTarget, setEditTarget] = useState<RoutingRule | null>(null)
+  const [deleteTarget, setDeleteTarget] = useState<RoutingRule | null>(null)
+
+  const handleCreate = async (data: RoutingRuleCreate) => {
+    await createMutation.mutateAsync(data)
+    setShowCreate(false)
+  }
+
+  const handleUpdate = async (data: RoutingRuleUpdate) => {
+    if (editTarget) {
+      await updateMutation.mutateAsync({ id: editTarget.id, ...data })
+      setEditTarget(null)
+    }
+  }
+
+  const handleDelete = async () => {
+    if (deleteTarget) {
+      await deleteMutation.mutateAsync(deleteTarget.id)
+      setDeleteTarget(null)
+    }
+  }
+
+  const handleApply = async () => {
+    await applyMutation.mutateAsync()
+  }
+
+  if (!selectedInstanceId) {
+    return (
+      <div>
+        <h2 className="text-2xl font-bold text-gray-900 mb-6">Routing Rules</h2>
+        <EmptyState
+          icon={Route}
+          title="Select an Instance"
+          description="Choose an instance from the dropdown above to manage its routing rules."
+        />
+        <div className="mt-4">
+          <InstanceSelector />
+        </div>
+      </div>
+    )
+  }
+
+  if (isLoading) return <LoadingSpinner />
+
+  const columns = [
+    {
+      key: 'order',
+      header: '#',
+      render: (rule: RoutingRule) => (
+        <span className="text-gray-400 text-xs w-4">{rule.order_index}</span>
+      ),
+    },
+    {
+      key: 'name',
+      header: 'Name',
+      render: (rule: RoutingRule) => (
+        <div>
+          <p className="font-medium text-gray-900">{rule.name}</p>
+        </div>
+      ),
+    },
+    {
+      key: 'match',
+      header: 'Match Conditions',
+      render: (rule: RoutingRule) => (
+        <div className="text-sm text-gray-600 space-y-0.5">
+          {rule.source_network && <span>Src: {rule.source_network}</span>}
+          {rule.dest_network && <span>Dst: {rule.dest_network}</span>}
+          {rule.service && <span>Service: {rule.service}</span>}
+          {rule.inbound_interface && <span>In: {rule.inbound_interface}</span>}
+          {!rule.source_network && !rule.dest_network && !rule.service && !rule.inbound_interface && (
+            <span className="text-gray-400">Any</span>
+          )}
+        </div>
+      ),
+    },
+    {
+      key: 'action',
+      header: 'Action',
+      render: (rule: RoutingRule) => (
+        <div className="text-sm text-gray-600 space-y-0.5">
+          {rule.gateway && <span>Gateway: {rule.gateway}</span>}
+          {rule.outbound_interface && <span>Out: {rule.outbound_interface}</span>}
+          {rule.mark && <span>Mark: {rule.mark}</span>}
+        </div>
+      ),
+    },
+    {
+      key: 'status',
+      header: 'Status',
+      render: (rule: RoutingRule) => (
+        <span className={`px-2 py-0.5 rounded text-xs ${rule.enabled ? 'bg-green-100 text-green-700' : 'bg-gray-100 text-gray-600'}`}>
+          {rule.enabled ? 'Enabled' : 'Disabled'}
+        </span>
+      ),
+    },
+    {
+      key: 'actions',
+      header: '',
+      render: (rule: RoutingRule) => (
+        <div className="flex items-center gap-2">
+          <button
+            onClick={() => setEditTarget(rule)}
+            className="text-sm text-primary-600 hover:text-primary-700"
+          >
+            Edit
+          </button>
+          <button
+            onClick={() => setDeleteTarget(rule)}
+            className="text-sm text-red-600 hover:text-red-700"
+          >
+            Delete
+          </button>
+        </div>
+      ),
+    },
+  ]
+
+  return (
+    <div>
+      <div className="flex items-center justify-between mb-6">
+        <h2 className="text-2xl font-bold text-gray-900">Routing Rules</h2>
+        <div className="flex items-center gap-2">
+          <InstanceSelector />
+        </div>
+      </div>
+
+      <div className="flex items-center gap-2 mb-4">
+        <button
+          onClick={() => setShowCreate(true)}
+          className="flex items-center gap-2 px-4 py-2 bg-primary-600 text-white rounded-lg hover:bg-primary-700 text-sm"
+        >
+          <Plus className="w-4 h-4" />
+          Add Rule
+        </button>
+        <button
+          onClick={handleApply}
+          disabled={applyMutation.isPending}
+          className="flex items-center gap-2 px-4 py-2 bg-white border border-gray-200 text-gray-700 rounded-lg hover:bg-gray-50 text-sm disabled:opacity-50"
+        >
+          <Upload className="w-4 h-4" />
+          {applyMutation.isPending ? 'Applying...' : 'Apply Rules'}
+        </button>
+      </div>
+
+      <DataTable
+        columns={columns}
+        data={rules || []}
+        keyExtractor={(rule) => rule.id}
+        emptyContent={
+          <EmptyState
+            icon={Route}
+            title="No Routing Rules"
+            description="Create your first routing rule to manage traffic flow."
+            actionLabel="Add Rule"
+            onAction={() => setShowCreate(true)}
+          />
+        }
+      />
+
+      <Modal open={showCreate} onClose={() => setShowCreate(false)} title="Create Routing Rule">
+        <RoutingRuleForm
+          onSubmit={handleCreate}
+          onCancel={() => setShowCreate(false)}
+          loading={createMutation.isPending}
+        />
+      </Modal>
+
+      <Modal open={!!editTarget} onClose={() => setEditTarget(null)} title="Edit Routing Rule">
+        {editTarget && (
+          <RoutingRuleForm
+            initial={editTarget}
+            onSubmit={handleUpdate}
+            onCancel={() => setEditTarget(null)}
+            loading={updateMutation.isPending}
+          />
+        )}
+      </Modal>
+
+      <ConfirmDialog
+        open={!!deleteTarget}
+        onClose={() => setDeleteTarget(null)}
+        onConfirm={handleDelete}
+        title="Delete Routing Rule"
+        message={`Are you sure you want to delete "${deleteTarget?.name}"?`}
+        loading={deleteMutation.isPending}
+      />
+    </div>
+  )
+}
+
+// Routing Rule Form Component
+interface RoutingRuleFormProps {
+  initial?: RoutingRule
+  onSubmit: (data: RoutingRuleCreate) => void
+  onCancel: () => void
+  loading: boolean
+}
+
+function RoutingRuleForm({ initial, onSubmit, onCancel, loading }: RoutingRuleFormProps) {
+  const [form, setForm] = useState<RoutingRuleCreate>({
+    name: initial?.name || '',
+    enabled: initial?.enabled ?? true,
+    source_network: initial?.source_network || '',
+    dest_network: initial?.dest_network || '',
+    service: initial?.service || '',
+    inbound_interface: initial?.inbound_interface || '',
+    gateway: initial?.gateway || '',
+    outbound_interface: initial?.outbound_interface || '',
+    mark: initial?.mark,
+    order_index: initial?.order_index,
+  })
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault()
+    onSubmit(form)
+  }
+
+  const inputClass = "w-full px-3 py-2 border border-gray-200 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500"
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4">
+      <div>
+        <label className="block text-sm font-medium text-gray-700 mb-1">Name</label>
+        <input
+          type="text"
+          value={form.name}
+          onChange={(e) => setForm({ ...form, name: e.target.value })}
+          className={inputClass}
+          placeholder="e.g. Route DMZ to WAN"
+          required
+        />
+      </div>
+
+      <div className="flex items-center gap-2">
+        <input
+          type="checkbox"
+          id="enabled"
+          checked={form.enabled}
+          onChange={(e) => setForm({ ...form, enabled: e.target.checked })}
+          className="w-4 h-4"
+        />
+        <label htmlFor="enabled" className="text-sm text-gray-700">Enabled</label>
+      </div>
+
+      <div className="grid grid-cols-2 gap-4">
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-1">Source Network</label>
+          <input
+            type="text"
+            value={form.source_network || ''}
+            onChange={(e) => setForm({ ...form, source_network: e.target.value || undefined })}
+            className={inputClass}
+            placeholder="10.0.0.0/24"
+          />
+        </div>
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-1">Dest Network</label>
+          <input
+            type="text"
+            value={form.dest_network || ''}
+            onChange={(e) => setForm({ ...form, dest_network: e.target.value || undefined })}
+            className={inputClass}
+            placeholder="0.0.0.0/0"
+          />
+        </div>
+      </div>
+
+      <div className="grid grid-cols-2 gap-4">
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-1">Service</label>
+          <input
+            type="text"
+            value={form.service || ''}
+            onChange={(e) => setForm({ ...form, service: e.target.value || undefined })}
+            className={inputClass}
+            placeholder="tcp/80"
+          />
+        </div>
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-1">Inbound Interface</label>
+          <input
+            type="text"
+            value={form.inbound_interface || ''}
+            onChange={(e) => setForm({ ...form, inbound_interface: e.target.value || undefined })}
+            className={inputClass}
+            placeholder="eth0"
+          />
+        </div>
+      </div>
+
+      <div className="grid grid-cols-2 gap-4">
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-1">Gateway</label>
+          <input
+            type="text"
+            value={form.gateway || ''}
+            onChange={(e) => setForm({ ...form, gateway: e.target.value || undefined })}
+            className={inputClass}
+            placeholder="192.168.1.1"
+          />
+        </div>
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-1">Outbound Interface</label>
+          <input
+            type="text"
+            value={form.outbound_interface || ''}
+            onChange={(e) => setForm({ ...form, outbound_interface: e.target.value || undefined })}
+            className={inputClass}
+            placeholder="eth1"
+          />
+        </div>
+      </div>
+
+      <div>
+        <label className="block text-sm font-medium text-gray-700 mb-1">Firewall Mark (fwmark)</label>
+        <input
+          type="number"
+          value={form.mark || ''}
+          onChange={(e) => setForm({ ...form, mark: e.target.value ? parseInt(e.target.value) : undefined })}
+          className={inputClass}
+          placeholder="100"
+        />
+      </div>
+
+      <div className="flex items-center justify-end gap-2 pt-4">
+        <button
+          type="button"
+          onClick={onCancel}
+          className="px-4 py-2 text-gray-700 hover:bg-gray-50 rounded-lg text-sm"
+        >
+          Cancel
+        </button>
+        <button
+          type="submit"
+          disabled={loading}
+          className="px-4 py-2 bg-primary-600 text-white rounded-lg hover:bg-primary-700 text-sm disabled:opacity-50"
+        >
+          {loading ? 'Saving...' : initial ? 'Update' : 'Create'}
+        </button>
+      </div>
+    </form>
+  )
+}

--- a/web-ui/src/router.tsx
+++ b/web-ui/src/router.tsx
@@ -11,6 +11,8 @@ import { TrafficShaping } from './pages/TrafficShaping'
 import { Users } from './pages/Users'
 import { Settings } from './pages/Settings'
 import { Metrics } from './pages/Metrics'
+import { AuditLogs } from './pages/AuditLogs'
+import { RoutingRules } from './pages/RoutingRules'
 import { ProtectedRoute } from './components/ProtectedRoute'
 import { VPNServers } from './pages/VPN/VPNServers'
 import { VPNCreate } from './pages/VPN/VPNCreate'
@@ -47,6 +49,10 @@ export const router = createBrowserRouter([
       {
         path: 'firewall',
         element: <FirewallRules />,
+      },
+      {
+        path: 'routing',
+        element: <RoutingRules />,
       },
       {
         path: 'firewall/simulator',
@@ -91,6 +97,10 @@ export const router = createBrowserRouter([
       {
         path: 'metrics',
         element: <Metrics />,
+      },
+      {
+        path: 'audit',
+        element: <AuditLogs />,
       },
       {
         path: 'settings',

--- a/web-ui/src/types/index.ts
+++ b/web-ui/src/types/index.ts
@@ -536,6 +536,50 @@ export interface ApiError {
   detail: string;
 }
 
+// Routing Types
+export interface RoutingRule {
+  id: number;
+  instance_id: number;
+  name: string;
+  enabled: boolean;
+  source_network?: string;
+  dest_network?: string;
+  service?: string;
+  inbound_interface?: string;
+  gateway?: string;
+  outbound_interface?: string;
+  mark?: number;
+  order_index: number;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface RoutingRuleCreate {
+  name: string;
+  enabled?: boolean;
+  source_network?: string;
+  dest_network?: string;
+  service?: string;
+  inbound_interface?: string;
+  gateway?: string;
+  outbound_interface?: string;
+  mark?: number;
+  order_index?: number;
+}
+
+export interface RoutingRuleUpdate {
+  name?: string;
+  enabled?: boolean;
+  source_network?: string;
+  dest_network?: string;
+  service?: string;
+  inbound_interface?: string;
+  gateway?: string;
+  outbound_interface?: string;
+  mark?: number;
+  order_index?: number;
+}
+
 // Metrics Types
 export interface MetricSnapshot {
   id: number;


### PR DESCRIPTION
## Summary

Adds the two missing frontend pages for features that already have working backends: Audit Logs and Routing Rules.

## What's New

### Audit Logs Page (`/audit`)
- Full audit log table with columns: Time, Action, Resource, User, Instance, IP Address
- Action badges with color coding (create=green, update=blue, delete=red, deploy=purple)
- Filters by action type and resource type
- Admin-only access (hidden from sidebar for non-admins)
- Refresh button

### Routing Rules Page (`/routing`)
- Full CRUD for routing rules per instance
- Table columns: Order, Name, Match Conditions, Action, Status
- Create/Edit form with all fields:
  - Name, enabled toggle
  - Source/Dest network, service, inbound interface
  - Gateway, outbound interface, firewall mark (fwmark)
- Apply Rules button to trigger deployment
- Instance selector integration

### Navigation Updates
- Sidebar now shows **Routing** link for all users
- Sidebar now shows **Audit Logs** link for admin/superadmin users only
- React Router updated with `/routing` and `/audit` routes

### API Hooks Added
- `useRoutingRules`, `useCreateRoutingRule`, `useUpdateRoutingRule`, `useDeleteRoutingRule`, `useApplyRouting`

## Testing

- Backend tests pass
- Frontend type-check, lint, tests, and build all pass