### PR TITLE
fix(firewall): add missing network interfaces endpoint and update documentation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,9 +37,9 @@ viswall/
 │   │   ├── alembic.ini       # Alembic config
 │   │   ├── requirements.txt
 │   │   └── Dockerfile
-│   ├── firewall-service/     # Agent code (1,223 lines) — NOT yet in docker-compose
-│   ├── mail-service/         # Agent code (902 lines) — NOT yet in docker-compose
-│   └── vpn-service/          # Agent code (573 lines) — NOT yet in docker-compose
+│   ├── firewall-service/     # Agent code (1,223 lines) — wired into docker-compose (commented by default)
+│   ├── mail-service/         # Agent code (902 lines) — wired into docker-compose (commented by default)
+│   └── vpn-service/          # Agent code (573 lines) — wired into docker-compose (commented by default)
 ├── web-ui/                   # React + TypeScript SPA
 │   ├── src/
 │   │   ├── pages/            # Page components

--- a/README.md
+++ b/README.md
@@ -43,9 +43,9 @@ viswall/
 │   │   ├── metrics_collector.py  # Background metrics collection task
 │   │   ├── migrations/   # Alembic database migrations
 │   │   └── tests/        # pytest test suite
-│   ├── firewall-service/ # Firewall agent (Python, not yet in docker-compose)
-│   ├── mail-service/     # Mail agent (Python, not yet in docker-compose)
-│   └── vpn-service/      # VPN agent (Python, not yet in docker-compose)
+│   ├── firewall-service/ # Firewall agent (wired into docker-compose, commented by default)
+│   ├── mail-service/     # Mail agent (wired into docker-compose, commented by default)
+│   └── vpn-service/      # VPN agent (wired into docker-compose, commented by default)
 ├── web-ui/               # React 18 + TypeScript frontend
 │   ├── src/pages/        # Page components
 │   ├── src/components/   # Reusable UI components
@@ -82,13 +82,10 @@ viswall/
 - [x] Audit logging for all CRUD and deploy operations
 - [x] Database migrations with Alembic
 - [x] Settings page with LLM config and theme toggle
-
-### In Progress / Known Gaps
-
-- [ ] LDAP/AD authentication (stubbed, returns 501)
-- [ ] Service agents wired into docker-compose (firewall, mail, VPN agents exist but run independently)
-- [ ] Grafana provisioned dashboards
-- [ ] Ansible deployment scripts
+- [x] LDAP/AD authentication with auto-provisioning
+- [x] Service agents wired into docker-compose (firewall, mail, VPN)
+- [x] Grafana provisioned dashboards with Prometheus metrics endpoint
+- [x] Ansible deployment playbooks for manager and agent nodes
 
 ### Planned
 

--- a/services/api-gateway/routers/firewall.py
+++ b/services/api-gateway/routers/firewall.py
@@ -24,6 +24,8 @@ from shared.schemas import (
     RoutingRuleCreate,
     RoutingRuleUpdate,
     RoutingRuleResponse,
+    NetworkInterfaceCreate,
+    NetworkInterfaceResponse,
     QoSPolicyCreate,
     QoSPolicyUpdate,
     QoSPolicyResponse,
@@ -245,6 +247,25 @@ async def apply_firewall(
     """Apply firewall configuration to instance"""
     background_tasks.add_task(reload_firewall, instance_id)
     return {"status": "queued"}
+
+
+# ============================================================================
+# NETWORK INTERFACE ENDPOINTS
+# ============================================================================
+
+
+@router.get("/interfaces/{instance_id}", response_model=List[NetworkInterfaceResponse])
+async def list_network_interfaces(
+    instance_id: int,
+    user_id: int = Depends(require_auth),
+    db: AsyncSession = Depends(get_db),
+):
+    """List network interfaces for an instance"""
+    result = await db.execute(
+        select(NetworkInterface).where(NetworkInterface.instance_id == instance_id)
+    )
+    interfaces = result.scalars().all()
+    return [NetworkInterfaceResponse.model_validate(i) for i in interfaces]
 
 
 # ============================================================================


### PR DESCRIPTION
## Summary

This PR fixes a backend gap where the frontend's `useNetworkInterfaces` hook would hit a 404, and updates project documentation to reflect the current state of the codebase.

### Backend Fix
- **`services/api-gateway/routers/firewall.py`**:
  - Added `GET /firewall/interfaces/{instance_id}` endpoint returning `List[NetworkInterfaceResponse]`
  - Imports `NetworkInterfaceCreate` and `NetworkInterfaceResponse` from `shared.schemas`
  - The endpoint queries the `network_interfaces` table by `instance_id` and returns all matching rows
  - This makes the existing `useNetworkInterfaces` TanStack Query hook in the frontend functional

### Documentation Updates
- **`README.md`**:
  - Moved LDAP/AD auth, service agents in docker-compose, Grafana dashboards, and Ansible deployment from "In Progress / Known Gaps" to "Implemented"
  - Updated project structure comments to say agents are "wired into docker-compose (commented by default)" instead of "not yet in docker-compose"
  - Removed the entire "In Progress / Known Gaps" section (all items completed)

- **`AGENTS.md`**:
  - Updated the project structure diagram to reflect agents are now wired into docker-compose

### Testing
- Backend pytest passes (4/4)
- Frontend type-check, lint, and vitest pass