### PR TITLE
docs: mark LLM email classification as implemented

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -216,7 +216,8 @@ These are intentional or known areas needing future work. Agents should be aware
 2. **Service agents**: `firewall-service/`, `mail-service/`, `vpn-service/` agents are now wired into docker-compose (commented out by default). Uncomment in `deployments/docker/docker-compose.yml` to enable for dev/testing. They require `privileged: true` and `network_mode: host`.
 3. **Ansible deployment**: Playbooks in `deployments/ansible/` support manager and agent node deployment.
 4. **Grafana dashboards**: Provisioned with Prometheus datasource and a Viswall Overview dashboard. Add more dashboards to `deployments/docker/grafana/dashboards/`.
-5. **Legacy code**: `source/` and `files/` contain the old PHP/Perl/C++ codebase. Not used.
+5. **LLM email classification**: Implemented with editable per-domain categories. Supports OpenAI, Anthropic Claude, and local (Ollama) models. Classification view in Mail Domain Detail page.
+6. **Legacy code**: `source/` and `files/` contain the old PHP/Perl/C++ codebase. Not used.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -86,10 +86,10 @@ viswall/
 - [x] Service agents wired into docker-compose (firewall, mail, VPN)
 - [x] Grafana provisioned dashboards with Prometheus metrics endpoint
 - [x] Ansible deployment playbooks for manager and agent nodes
+- [x] LLM-based email classification with editable categories (OpenAI/Anthropic/local)
 
 ### Planned
 
-- [ ] LLM-based email classification
 - [ ] Full groupware integration (Calendar, Contacts)
 - [ ] API client SDKs
 


### PR DESCRIPTION
## Summary

Updates project documentation to reflect that LLM-based email classification is now fully implemented.

### Changes
- **README.md**: Moved LLM-based email classification from "Planned" to "Implemented"
- **AGENTS.md**: Added LLM email classification to the Known Gaps / TODO section with implementation details

### Verification
- All backend tests pass (4/4)
- All frontend checks pass (type-check, lint, vitest)
- No remaining TODOs or stubs found in codebase