### PR TITLE
feat(sdk): CLI tool viswall-cli

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -146,14 +146,26 @@ Typical workflow:
    - Add route in `web-ui/src/router.tsx`.
    - Add sidebar link in `web-ui/src/components/Sidebar.tsx` if needed.
 
-3. **Tests**:
+3. **SDKs & CLI**:
+   - Any API change (new endpoints, modified schemas, removed fields) must be reflected in the SDKs and CLI.
+   - Export the updated OpenAPI spec: `python scripts/export_openapi.py`
+   - Update the **Python SDK** (`sdk/python/viswall/`) resource classes and tests.
+   - Regenerate **TypeScript SDK** types: `cd sdk/typescript && npm run generate-types`
+   - Update the **CLI** (`sdk/cli/viswall_cli/`) commands if new operations are exposed.
+   - Run SDK tests:
+     - Python SDK: `cd sdk/python && python -m pytest tests/ -v && python -m ruff check viswall/ && python -m mypy viswall/`
+     - TypeScript SDK: `cd sdk/typescript && npm run type-check && npm run test`
+     - CLI: `cd sdk/cli && python -m pytest tests/ -v && python -m ruff check viswall_cli/ && python -m mypy viswall_cli/`
+
+4. **Tests**:
    - Run backend tests: `cd services/api-gateway && python -m pytest tests/ -v --asyncio-mode=auto`
    - Run frontend checks: `cd web-ui && npm run type-check && npm run lint && npm run test:ci && npm run build`
+   - **All relevant tests must pass locally before creating a pull request.** Do not rely solely on CI to catch failures.
 
-4. **Commit & PR**:
-   - Create feature branch from `main`.
-   - One meaningful commit with clear message.
-   - Push and create PR. All CI must pass.
+5. **Commit & PR**:
+    - Create feature branch from `main`.
+    - One meaningful commit with clear message.
+    - Push and create PR. All CI must pass.
 
 ---
 

--- a/sdk/cli/README.md
+++ b/sdk/cli/README.md
@@ -1,0 +1,86 @@
+# viswall-cli
+
+Command-line interface for the Viswall distributed security appliance platform.
+
+## Installation
+
+```bash
+pip install viswall-cli
+```
+
+## Quick Start
+
+```bash
+# Login and save credentials
+viswall login --url https://viswall.example.com --username admin
+
+# Or use environment variables
+export VISWALL_URL=https://viswall.example.com
+export VISWALL_TOKEN=your-jwt-token
+```
+
+## Commands
+
+### Authentication
+```bash
+viswall login --url <url> --username <user>          # Interactive login
+viswall config-show                                   # Show current config
+```
+
+### Instances
+```bash
+viswall instances list                                # List all instances
+viswall instances create <name> <hostname>            # Create instance
+viswall instances get <id>                            # Get instance details
+viswall instances delete <id> --yes                   # Delete instance
+```
+
+### Firewall
+```bash
+viswall firewall list --instance-id <id>              # List rules
+viswall firewall create --instance-id <id> \
+  --name "Allow HTTPS" --action accept --dst-port 443  # Create rule
+viswall firewall delete <rule-id> --yes               # Delete rule
+viswall firewall apply <instance-id>                  # Apply rules
+```
+
+### Users
+```bash
+viswall users list                                    # List users
+viswall users create <username> <email> \
+  --password <pwd> --role admin                       # Create user
+```
+
+### Metrics
+```bash
+viswall metrics latest <instance-id>                  # Latest metrics
+viswall metrics overview                              # Global overview
+```
+
+## Global Options
+
+All commands support:
+- `--url, -u` — Viswall instance URL
+- `--token, -t` — JWT authentication token
+- `--format, -f` — Output format: `table` (default) or `json`
+- `--config, -c` — Path to config file
+
+## Configuration Priority
+
+1. Command-line flags (`--url`, `--token`)
+2. Environment variables (`VISWALL_URL`, `VISWALL_TOKEN`)
+3. Config file (`~/.config/viswall/config.yaml`)
+
+## Development
+
+```bash
+cd sdk/cli
+pip install -e ".[dev]" -e ../python
+python -m pytest tests/ -v
+python -m ruff check viswall_cli/
+python -m mypy viswall_cli/
+```
+
+## License
+
+MIT

--- a/sdk/cli/pyproject.toml
+++ b/sdk/cli/pyproject.toml
@@ -1,0 +1,63 @@
+[build-system]
+requires = ["setuptools>=61.0", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "viswall-cli"
+version = "0.1.0"
+description = "Command-line interface for Viswall distributed security appliance platform"
+readme = "README.md"
+license = { text = "MIT" }
+requires-python = ">=3.11"
+authors = [
+    { name = "Viswall Team", email = "dev@viswall.io" }
+]
+keywords = ["viswall", "security", "firewall", "cli", "vpn", "mail"]
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "Intended Audience :: System Administrators",
+    "License :: OSI Approved :: MIT License",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Topic :: System :: Networking :: Firewalls",
+    "Topic :: System :: Systems Administration",
+]
+dependencies = [
+    "viswall-sdk>=0.1.0",
+    "typer>=0.9.0",
+    "rich>=13.0.0",
+    "pydantic>=2.0.0",
+    "pyyaml>=6.0",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=7.4.0",
+    "pytest-httpx>=0.29.0",
+    "ruff>=0.1.0",
+    "mypy>=1.5.0",
+]
+
+[project.urls]
+Homepage = "https://github.com/hrohrweck/viswall"
+Documentation = "https://github.com/hrohrweck/viswall/tree/main/sdk/cli"
+Repository = "https://github.com/hrohrweck/viswall"
+
+[project.scripts]
+viswall = "viswall_cli.main:app"
+
+[tool.ruff]
+line-length = 100
+target-version = "py311"
+
+[tool.mypy]
+python_version = "3.11"
+warn_return_any = false
+warn_unused_configs = true
+disallow_untyped_defs = true
+ignore_missing_imports = true
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]

--- a/sdk/cli/tests/conftest.py
+++ b/sdk/cli/tests/conftest.py
@@ -1,0 +1,10 @@
+"""Pytest configuration for CLI tests."""
+
+import pytest
+
+
+@pytest.fixture
+def httpx_mock(httpx_mock):
+    """Override httpx_mock to clear existing responses."""
+    httpx_mock.reset()
+    return httpx_mock

--- a/sdk/cli/tests/test_cli.py
+++ b/sdk/cli/tests/test_cli.py
@@ -1,0 +1,220 @@
+"""Tests for Viswall CLI."""
+
+import os
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from viswall_cli.main import app
+from viswall_cli.config import Config
+
+runner = CliRunner()
+
+
+class TestLogin:
+    def test_login_success(self, httpx_mock, tmp_path):
+        httpx_mock.add_response(
+            url="https://viswall.example.com/api/v1/auth/login",
+            json={"access_token": "test-token", "token_type": "bearer"},
+        )
+
+        config_file = tmp_path / "config.yaml"
+        result = runner.invoke(
+            app,
+            [
+                "login",
+                "--url", "https://viswall.example.com",
+                "--username", "admin",
+                "--password", "secret",
+                "--config", str(config_file),
+            ],
+        )
+        assert result.exit_code == 0
+        assert "Logged in" in result.output
+
+    def test_login_failure(self, httpx_mock):
+        httpx_mock.add_response(
+            url="https://viswall.example.com/api/v1/auth/login",
+            status_code=401,
+            json={"detail": "Invalid credentials"},
+        )
+
+        result = runner.invoke(
+            app,
+            [
+                "login",
+                "--url", "https://viswall.example.com",
+                "--username", "admin",
+                "--password", "wrong",
+            ],
+        )
+        assert result.exit_code == 1
+        assert "Authentication failed" in result.output
+
+
+class TestConfig:
+    def test_config_show_empty(self, tmp_path):
+        config_file = tmp_path / "nonexistent.yaml"
+        result = runner.invoke(app, ["config-show", "--config", str(config_file)])
+        assert result.exit_code == 0
+        assert "No configuration found" in result.output
+
+    def test_config_show_with_env(self, monkeypatch):
+        monkeypatch.setenv("VISWALL_URL", "https://viswall.example.com")
+        monkeypatch.setenv("VISWALL_TOKEN", "my-secret-token")
+
+        result = runner.invoke(app, ["config-show"])
+        assert result.exit_code == 0
+        assert "https://viswall.example.com" in result.output
+        assert "my-secre...oken" in result.output
+
+
+class TestInstances:
+    def test_list_instances(self, httpx_mock, monkeypatch):
+        monkeypatch.setenv("VISWALL_URL", "https://viswall.example.com")
+        monkeypatch.setenv("VISWALL_TOKEN", "token")
+
+        httpx_mock.add_response(
+            url="https://viswall.example.com/api/v1/instances",
+            json=[
+                {"id": 1, "name": "edge-01", "hostname": "10.0.0.10", "status": "active"},
+            ],
+        )
+
+        result = runner.invoke(app, ["instances", "list"])
+        assert result.exit_code == 0
+        assert "edge-01" in result.output
+
+    def test_create_instance(self, httpx_mock, monkeypatch):
+        monkeypatch.setenv("VISWALL_URL", "https://viswall.example.com")
+        monkeypatch.setenv("VISWALL_TOKEN", "token")
+
+        httpx_mock.add_response(
+            url="https://viswall.example.com/api/v1/instances",
+            method="POST",
+            json={"id": 1, "name": "edge-01", "hostname": "10.0.0.10"},
+        )
+
+        result = runner.invoke(
+            app,
+            ["instances", "create", "edge-01", "10.0.0.10"],
+        )
+        assert result.exit_code == 0
+        assert "edge-01" in result.output
+
+    def test_delete_instance_confirm(self, httpx_mock, monkeypatch):
+        monkeypatch.setenv("VISWALL_URL", "https://viswall.example.com")
+        monkeypatch.setenv("VISWALL_TOKEN", "token")
+
+        httpx_mock.add_response(
+            url="https://viswall.example.com/api/v1/instances/1",
+            method="DELETE",
+            status_code=204,
+        )
+
+        result = runner.invoke(
+            app,
+            ["instances", "delete", "1", "--yes"],
+        )
+        assert result.exit_code == 0
+        assert "deleted" in result.output
+
+
+class TestFirewall:
+    def test_list_rules(self, httpx_mock, monkeypatch):
+        monkeypatch.setenv("VISWALL_URL", "https://viswall.example.com")
+        monkeypatch.setenv("VISWALL_TOKEN", "token")
+
+        httpx_mock.add_response(
+            url="https://viswall.example.com/api/v1/firewall/rules/1",
+            json=[
+                {"id": 1, "name": "allow-ssh", "action": "accept", "chain": "input", "protocol": "tcp", "dst_port": 22},
+            ],
+        )
+
+        result = runner.invoke(app, ["firewall", "list", "--instance-id", "1"])
+        assert result.exit_code == 0
+        assert "allow-ssh" in result.output
+
+    def test_create_rule(self, httpx_mock, monkeypatch):
+        monkeypatch.setenv("VISWALL_URL", "https://viswall.example.com")
+        monkeypatch.setenv("VISWALL_TOKEN", "token")
+
+        httpx_mock.add_response(
+            url="https://viswall.example.com/api/v1/firewall/rules/1",
+            method="POST",
+            json={"id": 1, "name": "allow-https", "action": "accept"},
+        )
+
+        result = runner.invoke(
+            app,
+            [
+                "firewall", "create",
+                "--instance-id", "1",
+                "--name", "allow-https",
+                "--action", "accept",
+                "--dst-port", "443",
+            ],
+        )
+        assert result.exit_code == 0
+        assert "allow-https" in result.output
+
+    def test_apply_firewall(self, httpx_mock, monkeypatch):
+        monkeypatch.setenv("VISWALL_URL", "https://viswall.example.com")
+        monkeypatch.setenv("VISWALL_TOKEN", "token")
+
+        httpx_mock.add_response(
+            url="https://viswall.example.com/api/v1/firewall/apply/1",
+            method="POST",
+            json={"status": "applied"},
+        )
+
+        result = runner.invoke(app, ["firewall", "apply", "1"])
+        assert result.exit_code == 0
+        assert "applied" in result.output
+
+
+class TestUsers:
+    def test_list_users(self, httpx_mock, monkeypatch):
+        monkeypatch.setenv("VISWALL_URL", "https://viswall.example.com")
+        monkeypatch.setenv("VISWALL_TOKEN", "token")
+
+        httpx_mock.add_response(
+            url="https://viswall.example.com/api/v1/users",
+            json=[
+                {"id": 1, "username": "admin", "email": "admin@example.com", "role": "admin"},
+            ],
+        )
+
+        result = runner.invoke(app, ["users", "list"])
+        assert result.exit_code == 0
+        assert "admin" in result.output
+
+
+class TestMetrics:
+    def test_metrics_latest(self, httpx_mock, monkeypatch):
+        monkeypatch.setenv("VISWALL_URL", "https://viswall.example.com")
+        monkeypatch.setenv("VISWALL_TOKEN", "token")
+
+        httpx_mock.add_response(
+            url="https://viswall.example.com/api/v1/metrics/latest/1",
+            json={"cpu_percent": 45.2, "memory_percent": 62.1},
+        )
+
+        result = runner.invoke(app, ["metrics", "latest", "1"])
+        assert result.exit_code == 0
+        assert "cpu_percent" in result.output
+
+    def test_metrics_overview(self, httpx_mock, monkeypatch):
+        monkeypatch.setenv("VISWALL_URL", "https://viswall.example.com")
+        monkeypatch.setenv("VISWALL_TOKEN", "token")
+
+        httpx_mock.add_response(
+            url="https://viswall.example.com/api/v1/metrics/overview",
+            json={"total_instances": 5, "active_instances": 4},
+        )
+
+        result = runner.invoke(app, ["metrics", "overview"])
+        assert result.exit_code == 0
+        assert "total_instances" in result.output

--- a/sdk/cli/viswall_cli/commands/__init__.py
+++ b/sdk/cli/viswall_cli/commands/__init__.py
@@ -1,0 +1,6 @@
+from viswall_cli.commands.instances import app as instances_app
+from viswall_cli.commands.firewall import app as firewall_app
+from viswall_cli.commands.users import app as users_app
+from viswall_cli.commands.metrics import app as metrics_app
+
+__all__ = ["instances_app", "firewall_app", "users_app", "metrics_app"]

--- a/sdk/cli/viswall_cli/commands/firewall.py
+++ b/sdk/cli/viswall_cli/commands/firewall.py
@@ -1,0 +1,109 @@
+"""Firewall commands."""
+
+from typing import Any, Dict, Optional
+
+import typer
+
+from viswall_cli.utils import get_client
+from viswall_cli.output import print_result, print_success, print_error
+from viswall.exceptions import ViswallAPIError
+
+app = typer.Typer(help="Manage firewall rules")
+
+
+@app.command("list")
+def list_rules(
+    instance_id: int = typer.Option(..., "--instance-id", "-i", help="Instance ID"),
+    url: Optional[str] = typer.Option(None, "--url", "-u"),
+    token: Optional[str] = typer.Option(None, "--token", "-t"),
+    format: str = typer.Option("table", "--format", "-f"),
+) -> None:
+    """List firewall rules for an instance."""
+    client = get_client(url=url, token=token)
+    try:
+        rules = client.firewall.list_rules(instance_id)
+        print_result(rules, format=format, columns=["id", "name", "action", "chain", "protocol", "dst_port"])
+    except ViswallAPIError as e:
+        print_error(str(e))
+        raise typer.Exit(1)
+
+
+@app.command()
+def create(
+    instance_id: int = typer.Option(..., "--instance-id", "-i", help="Instance ID"),
+    name: str = typer.Option(..., "--name", "-n", help="Rule name"),
+    action: str = typer.Option(..., "--action", "-a", help="Action: accept, drop, reject"),
+    chain: str = typer.Option("input", "--chain", "-c", help="Chain: input, output, forward"),
+    protocol: str = typer.Option("tcp", "--protocol", "-p", help="Protocol: tcp, udp, icmp, any"),
+    src_ip: Optional[str] = typer.Option(None, "--src-ip"),
+    dst_ip: Optional[str] = typer.Option(None, "--dst-ip"),
+    src_port: Optional[int] = typer.Option(None, "--src-port"),
+    dst_port: Optional[int] = typer.Option(None, "--dst-port"),
+    url: Optional[str] = typer.Option(None, "--url", "-u"),
+    token: Optional[str] = typer.Option(None, "--token", "-t"),
+    format: str = typer.Option("json", "--format", "-f"),
+) -> None:
+    """Create a firewall rule."""
+    client = get_client(url=url, token=token)
+    try:
+        data: Dict[str, Any] = {
+            "name": name,
+            "action": action,
+            "chain": chain,
+            "protocol": protocol,
+        }
+        if src_ip:
+            data["src_ip"] = src_ip
+        if dst_ip:
+            data["dst_ip"] = dst_ip
+        if src_port:
+            data["src_port"] = src_port
+        if dst_port:
+            data["dst_port"] = dst_port
+
+        rule = client.firewall.create_rule(instance_id, **data)
+        print_result(rule, format=format)
+        print_success(f"Rule '{name}' created")
+    except ViswallAPIError as e:
+        print_error(str(e))
+        raise typer.Exit(1)
+
+
+@app.command()
+def delete(
+    rule_id: int = typer.Argument(..., help="Rule ID"),
+    yes: bool = typer.Option(False, "--yes", "-y", help="Skip confirmation"),
+    url: Optional[str] = typer.Option(None, "--url", "-u"),
+    token: Optional[str] = typer.Option(None, "--token", "-t"),
+) -> None:
+    """Delete a firewall rule."""
+    if not yes:
+        confirm = typer.confirm(f"Delete rule {rule_id}?")
+        if not confirm:
+            raise typer.Abort()
+
+    client = get_client(url=url, token=token)
+    try:
+        client.firewall.delete_rule(rule_id)
+        print_success(f"Rule {rule_id} deleted")
+    except ViswallAPIError as e:
+        print_error(str(e))
+        raise typer.Exit(1)
+
+
+@app.command()
+def apply(
+    instance_id: int = typer.Argument(..., help="Instance ID"),
+    url: Optional[str] = typer.Option(None, "--url", "-u"),
+    token: Optional[str] = typer.Option(None, "--token", "-t"),
+) -> None:
+    """Apply firewall configuration to instance."""
+    client = get_client(url=url, token=token)
+    try:
+        result = client.firewall.apply_rules(instance_id)
+        print_success(f"Firewall rules applied to instance {instance_id}")
+        if result:
+            print_result(result, format="json")
+    except ViswallAPIError as e:
+        print_error(str(e))
+        raise typer.Exit(1)

--- a/sdk/cli/viswall_cli/commands/instances.py
+++ b/sdk/cli/viswall_cli/commands/instances.py
@@ -1,0 +1,89 @@
+"""Instance commands."""
+
+from typing import Optional
+
+import typer
+
+from viswall_cli.utils import get_client
+from viswall_cli.output import print_result, print_success, print_error
+from viswall.exceptions import ViswallAPIError
+
+app = typer.Typer(help="Manage Viswall instances")
+
+
+@app.command("list")
+def list_instances(
+    url: Optional[str] = typer.Option(None, "--url", "-u"),
+    token: Optional[str] = typer.Option(None, "--token", "-t"),
+    format: str = typer.Option("table", "--format", "-f"),
+) -> None:
+    """List all instances."""
+    client = get_client(url=url, token=token)
+    try:
+        instances = client.instances.list()
+        print_result(instances, format=format, columns=["id", "name", "hostname", "status"])
+    except ViswallAPIError as e:
+        print_error(str(e))
+        raise typer.Exit(1)
+
+
+@app.command()
+def create(
+    name: str = typer.Argument(..., help="Instance name"),
+    hostname: str = typer.Argument(..., help="Hostname or IP address"),
+    api_endpoint: Optional[str] = typer.Option(None, "--api-endpoint"),
+    url: Optional[str] = typer.Option(None, "--url", "-u"),
+    token: Optional[str] = typer.Option(None, "--token", "-t"),
+    format: str = typer.Option("json", "--format", "-f"),
+) -> None:
+    """Create a new instance."""
+    client = get_client(url=url, token=token)
+    try:
+        data = {"name": name, "hostname": hostname}
+        if api_endpoint:
+            data["api_endpoint"] = api_endpoint
+        instance = client.instances.create(**data)
+        print_result(instance, format=format)
+        print_success(f"Instance '{name}' created")
+    except ViswallAPIError as e:
+        print_error(str(e))
+        raise typer.Exit(1)
+
+
+@app.command()
+def get(
+    instance_id: int = typer.Argument(..., help="Instance ID"),
+    url: Optional[str] = typer.Option(None, "--url", "-u"),
+    token: Optional[str] = typer.Option(None, "--token", "-t"),
+    format: str = typer.Option("json", "--format", "-f"),
+) -> None:
+    """Get instance details."""
+    client = get_client(url=url, token=token)
+    try:
+        instance = client.instances.get(instance_id)
+        print_result(instance, format=format)
+    except ViswallAPIError as e:
+        print_error(str(e))
+        raise typer.Exit(1)
+
+
+@app.command()
+def delete(
+    instance_id: int = typer.Argument(..., help="Instance ID"),
+    yes: bool = typer.Option(False, "--yes", "-y", help="Skip confirmation"),
+    url: Optional[str] = typer.Option(None, "--url", "-u"),
+    token: Optional[str] = typer.Option(None, "--token", "-t"),
+) -> None:
+    """Delete an instance."""
+    if not yes:
+        confirm = typer.confirm(f"Are you sure you want to delete instance {instance_id}?")
+        if not confirm:
+            raise typer.Abort()
+
+    client = get_client(url=url, token=token)
+    try:
+        client.instances.delete(instance_id)
+        print_success(f"Instance {instance_id} deleted")
+    except ViswallAPIError as e:
+        print_error(str(e))
+        raise typer.Exit(1)

--- a/sdk/cli/viswall_cli/commands/metrics.py
+++ b/sdk/cli/viswall_cli/commands/metrics.py
@@ -1,0 +1,44 @@
+"""Metrics commands."""
+
+from typing import Optional
+
+import typer
+
+from viswall_cli.utils import get_client
+from viswall_cli.output import print_result, print_error
+from viswall.exceptions import ViswallAPIError
+
+app = typer.Typer(help="View metrics and monitoring data")
+
+
+@app.command("latest")
+def latest(
+    instance_id: int = typer.Argument(..., help="Instance ID"),
+    url: Optional[str] = typer.Option(None, "--url", "-u"),
+    token: Optional[str] = typer.Option(None, "--token", "-t"),
+    format: str = typer.Option("json", "--format", "-f"),
+) -> None:
+    """Get latest metrics for an instance."""
+    client = get_client(url=url, token=token)
+    try:
+        metrics = client.metrics.get_latest(instance_id)
+        print_result(metrics, format=format)
+    except ViswallAPIError as e:
+        print_error(str(e))
+        raise typer.Exit(1)
+
+
+@app.command()
+def overview(
+    url: Optional[str] = typer.Option(None, "--url", "-u"),
+    token: Optional[str] = typer.Option(None, "--token", "-t"),
+    format: str = typer.Option("json", "--format", "-f"),
+) -> None:
+    """Get global metrics overview."""
+    client = get_client(url=url, token=token)
+    try:
+        data = client.metrics.get_overview()
+        print_result(data, format=format)
+    except ViswallAPIError as e:
+        print_error(str(e))
+        raise typer.Exit(1)

--- a/sdk/cli/viswall_cli/commands/users.py
+++ b/sdk/cli/viswall_cli/commands/users.py
@@ -1,0 +1,53 @@
+"""User commands."""
+
+from typing import Optional
+
+import typer
+
+from viswall_cli.utils import get_client
+from viswall_cli.output import print_result, print_success, print_error
+from viswall.exceptions import ViswallAPIError
+
+app = typer.Typer(help="Manage users")
+
+
+@app.command("list")
+def list_users(
+    url: Optional[str] = typer.Option(None, "--url", "-u"),
+    token: Optional[str] = typer.Option(None, "--token", "-t"),
+    format: str = typer.Option("table", "--format", "-f"),
+) -> None:
+    """List all users."""
+    client = get_client(url=url, token=token)
+    try:
+        users = client.users.list()
+        print_result(users, format=format, columns=["id", "username", "email", "role", "created_at"])
+    except ViswallAPIError as e:
+        print_error(str(e))
+        raise typer.Exit(1)
+
+
+@app.command()
+def create(
+    username: str = typer.Argument(..., help="Username"),
+    email: str = typer.Argument(..., help="Email address"),
+    password: str = typer.Option(..., "--password", "-p", prompt=True, hide_input=True),
+    role: str = typer.Option("user", "--role", "-r", help="Role: admin or user"),
+    url: Optional[str] = typer.Option(None, "--url", "-u"),
+    token: Optional[str] = typer.Option(None, "--token", "-t"),
+    format: str = typer.Option("json", "--format", "-f"),
+) -> None:
+    """Create a new user."""
+    client = get_client(url=url, token=token)
+    try:
+        user = client.users.create(
+            username=username,
+            email=email,
+            password=password,
+            role=role,
+        )
+        print_result(user, format=format)
+        print_success(f"User '{username}' created")
+    except ViswallAPIError as e:
+        print_error(str(e))
+        raise typer.Exit(1)

--- a/sdk/cli/viswall_cli/config.py
+++ b/sdk/cli/viswall_cli/config.py
@@ -1,0 +1,67 @@
+"""Viswall CLI configuration management."""
+
+import os
+from pathlib import Path
+from typing import Optional
+
+import yaml
+
+
+DEFAULT_CONFIG_DIR = Path.home() / ".config" / "viswall"
+DEFAULT_CONFIG_FILE = DEFAULT_CONFIG_DIR / "config.yaml"
+
+
+class Config:
+    """CLI configuration."""
+
+    def __init__(self, url: Optional[str] = None, token: Optional[str] = None):
+        self.url = url
+        self.token = token
+
+    @classmethod
+    def from_env(cls) -> "Config":
+        """Load configuration from environment variables."""
+        return cls(
+            url=os.environ.get("VISWALL_URL"),
+            token=os.environ.get("VISWALL_TOKEN"),
+        )
+
+    @classmethod
+    def from_file(cls, path: Optional[Path] = None) -> "Config":
+        """Load configuration from file."""
+        config_path = path or DEFAULT_CONFIG_FILE
+        if not config_path.exists():
+            return cls()
+
+        with open(config_path) as f:
+            data = yaml.safe_load(f) or {}
+
+        return cls(
+            url=data.get("url"),
+            token=data.get("token"),
+        )
+
+    def save(self, path: Optional[Path] = None) -> None:
+        """Save configuration to file."""
+        config_path = path or DEFAULT_CONFIG_FILE
+        config_path.parent.mkdir(parents=True, exist_ok=True)
+
+        data = {}
+        if self.url:
+            data["url"] = self.url
+        if self.token:
+            data["token"] = self.token
+
+        with open(config_path, "w") as f:
+            yaml.dump(data, f, default_flow_style=False)
+
+    def merge(self, other: "Config") -> "Config":
+        """Merge another config, preferring non-None values from other."""
+        return Config(
+            url=other.url or self.url,
+            token=other.token or self.token,
+        )
+
+    def is_complete(self) -> bool:
+        """Check if config has all required values."""
+        return bool(self.url and self.token)

--- a/sdk/cli/viswall_cli/main.py
+++ b/sdk/cli/viswall_cli/main.py
@@ -1,0 +1,86 @@
+"""Viswall CLI main entrypoint."""
+
+from pathlib import Path
+from typing import Optional
+
+import typer
+from rich.console import Console
+
+from viswall import ViswallClient
+from viswall.exceptions import AuthenticationError, ViswallAPIError
+
+from viswall_cli.config import Config, DEFAULT_CONFIG_FILE
+from viswall_cli.output import print_error, print_success
+from viswall_cli.commands import instances_app, firewall_app, users_app, metrics_app
+
+app = typer.Typer(
+    name="viswall",
+    help="Command-line interface for Viswall security appliance platform",
+    no_args_is_help=True,
+)
+console = Console()
+
+
+@app.command()
+def login(
+    url: str = typer.Option(..., "--url", "-u", help="Viswall instance URL"),
+    username: str = typer.Option(..., "--username", "-U", help="Username"),
+    password: str = typer.Option(..., "--password", "-p", help="Password", prompt=True, hide_input=True),
+    config_file: Optional[Path] = typer.Option(None, "--config", "-c", help="Config file path"),
+) -> None:
+    """Login and save credentials to config file."""
+    client = ViswallClient(base_url=url)
+    try:
+        result = client.auth.login(username, password)
+        token = result.get("access_token")
+        if not token:
+            print_error("Login failed: no access token in response")
+            raise typer.Exit(1)
+
+        config = Config(url=url, token=token)
+        config.save(config_file)
+        print_success(f"Logged in to {url}")
+    except AuthenticationError as e:
+        print_error(f"Authentication failed: {e}")
+        raise typer.Exit(1)
+    except ViswallAPIError as e:
+        print_error(f"API error: {e}")
+        raise typer.Exit(1)
+
+
+@app.command()
+def config_show(
+    config_file: Optional[Path] = typer.Option(None, "--config", "-c", help="Config file path"),
+) -> None:
+    """Show current configuration."""
+    config = Config.from_file(config_file)
+    env_config = Config.from_env()
+    merged = config.merge(env_config)
+
+    if not merged.url and not merged.token:
+        console.print("[dim]No configuration found.[/dim]")
+        console.print(f"Config file: {config_file or DEFAULT_CONFIG_FILE}")
+        return
+
+    console.print(f"URL:   {merged.url or '[dim]not set[/dim]'}")
+    if merged.token:
+        masked = merged.token[:8] + "..." + merged.token[-4:]
+        console.print(f"Token: {masked}")
+    else:
+        console.print("Token: [dim]not set[/dim]")
+
+
+app.add_typer(instances_app, name="instances")
+app.add_typer(firewall_app, name="firewall")
+app.add_typer(users_app, name="users")
+app.add_typer(metrics_app, name="metrics")
+
+
+@app.callback()
+def main(
+    version: bool = typer.Option(False, "--version", "-v", help="Show version"),
+) -> None:
+    """Viswall CLI — manage your security appliances."""
+    if version:
+        console.print("viswall-cli 0.1.0")
+        raise typer.Exit()

--- a/sdk/cli/viswall_cli/output.py
+++ b/sdk/cli/viswall_cli/output.py
@@ -1,0 +1,61 @@
+"""Viswall CLI output formatting."""
+
+import json
+from typing import Any, Dict, List, Optional
+
+from rich.console import Console
+from rich.table import Table
+
+
+console = Console()
+
+
+def print_json(data: Any) -> None:
+    """Print data as formatted JSON."""
+    console.print_json(json.dumps(data, default=str))
+
+
+def print_table(
+    data: List[Dict[str, Any]],
+    columns: Optional[List[str]] = None,
+    title: Optional[str] = None,
+) -> None:
+    """Print list of dicts as a table."""
+    if not data:
+        console.print("[dim]No data.[/dim]")
+        return
+
+    if columns is None:
+        columns = list(data[0].keys())
+
+    table = Table(title=title, show_header=True, header_style="bold magenta")
+    for col in columns:
+        table.add_column(str(col))
+
+    for row in data:
+        table.add_row(*[str(row.get(col, "")) for col in columns])
+
+    console.print(table)
+
+
+def print_result(data: Any, format: str = "table", columns: Optional[List[str]] = None) -> None:
+    """Print result in specified format."""
+    if format == "json":
+        print_json(data)
+    elif format == "table":
+        if isinstance(data, list):
+            print_table(data, columns=columns)
+        else:
+            print_json(data)
+    else:
+        console.print(str(data))
+
+
+def print_success(message: str) -> None:
+    """Print a success message."""
+    console.print(f"[green]✓[/green] {message}")
+
+
+def print_error(message: str) -> None:
+    """Print an error message."""
+    console.print(f"[red]✗[/red] {message}")

--- a/sdk/cli/viswall_cli/utils.py
+++ b/sdk/cli/viswall_cli/utils.py
@@ -1,0 +1,40 @@
+"""Shared utilities for CLI commands."""
+
+from pathlib import Path
+from typing import Optional
+
+import typer
+
+from viswall import ViswallClient
+from viswall_cli.config import Config
+from viswall_cli.output import print_error
+
+
+def get_client(
+    url: Optional[str] = None,
+    token: Optional[str] = None,
+    config_file: Optional[Path] = None,
+) -> ViswallClient:
+    """Create a ViswallClient from CLI options, env vars, and config file."""
+    file_config = Config.from_file(config_file)
+    env_config = Config.from_env()
+    cli_config = Config(url=url, token=token)
+
+    # Priority: CLI > env > file
+    config = file_config.merge(env_config).merge(cli_config)
+
+    if not config.url:
+        print_error(
+            "No URL configured. Set --url, VISWALL_URL environment variable, "
+            "or run 'viswall login' to configure."
+        )
+        raise typer.Exit(1)
+
+    if not config.token:
+        print_error(
+            "No token configured. Set --token, VISWALL_TOKEN environment variable, "
+            "or run 'viswall login' to configure."
+        )
+        raise typer.Exit(1)
+
+    return ViswallClient(base_url=config.url, token=config.token)


### PR DESCRIPTION
## Summary

This PR introduces the command-line interface (`viswall-cli`) for the Viswall API, built on top of the Python SDK.

### Features

#### Authentication
- `viswall login --url <url> --username <user>` — Interactive login with password prompt
- `viswall config-show` — Display current configuration with masked token
- Config priority: CLI flags > environment variables (`VISWALL_URL`, `VISWALL_TOKEN`) > config file (`~/.config/viswall/config.yaml`)

#### Commands
| Command | Description |
|---------|-------------|
| `instances list` | List all instances (table/json) |
| `instances create <name> <hostname>` | Create new instance |
| `instances get <id>` | Get instance details |
| `instances delete <id> --yes` | Delete instance with confirmation |
| `firewall list --instance-id <id>` | List firewall rules |
| `firewall create --instance-id <id> --name ... --action ...` | Create rule |
| `firewall delete <rule-id> --yes` | Delete rule |
| `firewall apply <instance-id>` | Apply configuration |
| `users list` | List all users |
| `users create <username> <email> --password ...` | Create user |
| `metrics latest <instance-id>` | Get latest metrics |
| `metrics overview` | Global metrics overview |

#### Output Formatting
- `--format table` (default) — Rich-formatted tables for lists
- `--format json` — JSON output for all commands
- Colored success/error messages

### Example Usage

```bash
# Login
viswall login --url https://viswall.example.com --username admin

# List instances
viswall instances list

# Create firewall rule
viswall firewall create --instance-id 1 \
  --name "Allow HTTPS" --action accept --dst-port 443

# Apply rules
viswall firewall apply 1

# Get metrics
viswall metrics latest 1
```

### Testing
- 13 pytest tests covering login, config, instances, firewall, users, metrics
- Uses `typer.testing.CliRunner` and `pytest-httpx` for HTTP mocking
- All tests pass

### Infrastructure
- `sdk/cli/pyproject.toml` — Package config with console script entry point
- `sdk/cli/viswall_cli/` — Main package
- `sdk/cli/tests/` — pytest test suite
- Depends on `viswall-sdk>=0.1.0`
- Build, lint (ruff), and type-check (mypy) all pass