### PR TITLE
docs(readme): mark SDKs as implemented + extend CI for TS SDK and CLI

### DIFF
--- a/.github/workflows/sdk.yml
+++ b/.github/workflows/sdk.yml
@@ -89,3 +89,68 @@ jobs:
         run: |
           cd sdk/python
           python -m mypy viswall/
+
+  test-typescript-sdk:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      
+      - name: Install TypeScript SDK dependencies
+        run: |
+          cd sdk/typescript
+          npm ci
+      
+      - name: Run TypeScript type check
+        run: |
+          cd sdk/typescript
+          npx tsc --noEmit
+      
+      - name: Run TypeScript SDK tests
+        run: |
+          cd sdk/typescript
+          npx vitest run
+      
+      - name: Build TypeScript SDK
+        run: |
+          cd sdk/typescript
+          npx tsc
+
+  test-cli:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      
+      - name: Install Python SDK
+        run: |
+          cd sdk/python
+          pip install -e ".[dev]"
+      
+      - name: Install CLI
+        run: |
+          cd sdk/cli
+          pip install -e ".[dev]"
+      
+      - name: Run CLI tests
+        run: |
+          cd sdk/cli
+          python -m pytest tests/ -v
+      
+      - name: Run ruff on CLI
+        run: |
+          cd sdk/cli
+          python -m ruff check viswall_cli/
+      
+      - name: Run mypy on CLI
+        run: |
+          cd sdk/cli
+          python -m mypy viswall_cli/

--- a/README.md
+++ b/README.md
@@ -88,10 +88,46 @@ viswall/
 - [x] Ansible deployment playbooks for manager and agent nodes
 - [x] LLM-based email classification with editable categories (OpenAI/Anthropic/local)
 - [x] Groupware integration (SOGo with CalDAV/CardDAV/ActiveSync via nginx reverse proxy)
+- [x] Python SDK (`viswall-sdk`) with resource-oriented API
+- [x] TypeScript SDK (`@viswall/sdk`) with auto-generated OpenAPI types
+- [x] CLI tool (`viswall-cli`) for scripting and automation
 
-### Planned
+## 📦 SDKs & CLI
 
-- [ ] API client SDKs
+### Python SDK
+
+```bash
+cd sdk/python
+pip install -e ".[dev]"
+python -m pytest tests/ -v
+```
+
+### TypeScript SDK
+
+```bash
+cd sdk/typescript
+npm install
+npm run generate-types  # Regenerate from OpenAPI spec
+npm run type-check
+npm run test
+npm run build
+```
+
+### CLI Tool
+
+```bash
+cd sdk/cli
+pip install -e ".[dev]" -e ../python
+
+# Login
+viswall login --url https://viswall.example.com --username admin
+
+# List instances
+viswall instances list
+
+# Create firewall rule
+viswall firewall create --instance-id 1 --name "Allow HTTPS" --action accept --dst-port 443
+```
 
 ## 🔧 Development
 


### PR DESCRIPTION
## Summary

Updates README and CI to reflect the completed SDK initiative.

### README Changes
- Marked Python SDK, TypeScript SDK, and CLI as **implemented**
- Removed "API client SDKs" from Planned section
- Added new **SDKs & CLI** section with quick-start examples for all three packages

### CI Changes
- Added `test-typescript-sdk` job:
  - `npm ci` in `sdk/typescript`
  - `tsc --noEmit` (type-check)
  - `vitest run` (tests)
  - `tsc` (build)
- Added `test-cli` job:
  - Installs Python SDK dependency
  - Installs CLI with dev dependencies
  - `pytest tests/ -v`
  - `ruff check viswall_cli/`
  - `mypy viswall_cli/`

This ensures all three SDK packages are validated on every API change.