### PR TITLE
feat(infra): add Ollama container and LLM provider registry tables (#A)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,150 +1,239 @@
-# Viswall Modern Rewrite
+# Viswall
 
-This is a complete rewrite of the legacy viswall security appliance into a modern, distributed, containerized platform.
+Viswall is a modern, distributed security appliance platform for managing firewall, VPN, mail, and routing infrastructure across multiple edge instances from a single control plane. It replaces legacy monolithic security appliances with a containerized microservices architecture built on FastAPI, React, and PostgreSQL.
 
-## 🏗️ Architecture
+## What Viswall Does
 
-The new architecture follows microservices principles with:
+Viswall provides a centralized management layer for security-critical network services. Instead of configuring each firewall or mail server individually through SSH and text files, administrators use a web dashboard or API to define policies once and push them to any number of managed instances.
 
-- **API Gateway**: Central FastAPI-based management layer
-- **Web UI**: Modern React 18 + TypeScript SPA
-- **Modular Services**: Mail, Firewall, VPN as independent agent services
-- **Multi-instance Support**: Single UI managing multiple viswall instances
-- **Flexible Deployment**: Docker containers
+### Core Capabilities
 
-## 🚀 Quick Start
+**Multi-Instance Management.** A single Viswall manager can control dozens of edge instances. Each instance represents a physical or virtual appliance running firewall, VPN, or mail services. The manager tracks instance health through periodic heartbeats, collects metrics, and maintains a configuration version for each node so agents know when to pull updated rules.
 
-### Docker Deployment
+**Firewall Rules and NAT.** Define accept, drop, and reject rules across input, output, and forward chains. Rules support protocol filtering, source and destination IP ranges, and port specifications. NAT rules handle address translation. Rules are authored in the web UI or via API, stored in the manager's database, and applied to instances through a dedicated firewall agent.
+
+**VPN Servers and Clients.** Deploy WireGuard, IPsec, OpenVPN, L2TP, and PPTP servers across instances. Client configurations are generated automatically, including QR codes and downloadable profiles. Site-to-site tunnels bridge networks between instances.
+
+**Mail Domains and Users.** Host email for multiple domains with per-domain toggles for spam filtering, virus scanning, DKIM signing, DMARC policies, and SPF records. LLM-based email classification categorizes incoming mail using OpenAI, Anthropic Claude, or local Ollama models, with configurable per-domain categories. SOGo groupware provides CalDAV, CardDAV, and ActiveSync for mail users.
+
+**Policy Routing.** Direct traffic across specific gateways based on source or destination criteria, enabling multi-WAN failover and traffic segmentation.
+
+**Metrics and Monitoring.** A background metrics collector gathers CPU, memory, disk, network, and mail activity from every instance. Data is stored in PostgreSQL and visualized through Grafana dashboards backed by Prometheus.
+
+**Audit Logging.** Every create, update, delete, and deploy operation is logged with the user, timestamp, instance, and before/after state. Audit logs are queryable through the API and web UI.
+
+**Authentication.** Local JWT-based authentication supports role-based access control with admin, superadmin, user, and readonly roles. LDAP and Active Directory integration provides auto-provisioning for enterprise environments.
+
+**SDKs and Automation.** Resource-oriented Python and TypeScript SDKs wrap the entire REST API. A command-line tool (`viswall-cli`) enables scripting of instance provisioning, rule deployment, and metrics retrieval.
+
+---
+
+## Architecture
+
+Viswall separates the control plane (manager) from the data plane (agents). This architecture lets you run the manager in a central data center while agents operate on edge hardware close to the traffic they protect.
+
+```
+                               ┌─────────────────────────────────────────┐
+                               │           Manager Node                  │
+                               │  ┌──────────┐  ┌──────────┐  ┌──────┐ │
+                               │  │ Web UI   │  │ API      │  │ Nginx│ │
+                               │  │ (React)  │  │ Gateway  │  │(TLS) │ │
+                               │  └──────────┘  │ (FastAPI)│  └──────┘ │
+                               │                └────┬─────┘           │
+                               │                     │                  │
+                               │  ┌──────────────────┼────────────────┐│
+                               │  │ PostgreSQL       │ Redis          ││
+                               │  │ (state)          │ (cache/queues) ││
+                               │  └──────────────────┘────────────────┘│
+                               │         Prometheus + Grafana           │
+                               └──────────────────┬─────────────────────┘
+                                                  │ HTTPS / API
+                         ┌────────────────────────┼────────────────────────┐
+                         │                        │                        │
+                  ┌──────▼──────┐          ┌──────▼──────┐          ┌──────▼──────┐
+                  │  Instance 1 │          │  Instance 2 │          │  Instance N │
+                  │ ┌─────────┐ │          │ ┌─────────┐ │          │ ┌─────────┐ │
+                  │ │Firewall │ │          │ │  Mail   │ │          │ │   VPN   │ │
+                  │ │ Agent   │ │          │ │ Agent   │ │          │ │ Agent   │ │
+                  │ └─────────┘ │          │ └─────────┘ │          │ └─────────┘ │
+                  └─────────────┘          └─────────────┘          └─────────────┘
+```
+
+### Component Responsibilities
+
+**API Gateway** (`services/api-gateway/`). The central FastAPI application exposes the REST API used by the web UI, SDKs, and CLI. It owns the database schema, handles authentication, routes requests to domain-specific modules (auth, firewall, VPN, mail, metrics, routing, audit), and runs the background metrics collector. On startup, it applies any pending Alembic database migrations automatically.
+
+**Web UI** (`web-ui/`). A React 18 single-page application built with TypeScript, Vite, TanStack Query, Zustand, and Tailwind CSS. It provides pages for instance management, firewall rules, VPN configuration, mail domains, routing policies, metrics dashboards, audit logs, settings, and LLM classification review. The UI communicates exclusively with the API Gateway over HTTPS.
+
+**Nginx** (`deployments/docker/nginx/`). Acts as a reverse proxy in front of the API Gateway and Web UI containers. Handles TLS termination using either self-signed certificates or Let's Encrypt. Also proxies `/sogo` to the SOGo groupware container.
+
+**Agents** (`services/firewall-service/`, `mail-service/`, `vpn-service/`). Lightweight Python services that run on each managed instance. They poll the manager for configuration changes (via heartbeat responses that include a config version) and apply rules locally using iptables/nftables, Postfix/Dovecot, or WireGuard/IPsec tools. Agents are wired into the Docker Compose stack but commented out by default; in production they run on bare-metal or VM instances with `privileged: true` and `network_mode: host`.
+
+**PostgreSQL** (primary database). Stores all persistent state: users, instances, firewall rules, VPN servers and clients, mail domains and users, metrics snapshots, audit logs, and routing policies. SQLAlchemy 2.0 async models live in `shared/models.py`.
+
+**Redis** (cache and queues). Caches session data and acts as a lightweight message broker for background tasks.
+
+**Prometheus** (metrics scraping). Scrapes the `/metrics` endpoint on the API Gateway for application-level metrics.
+
+**Grafana** (visualization). Pre-provisioned with a Prometheus data source and a Viswall Overview dashboard showing instance health, resource utilization, and mail activity.
+
+**SOGo** (groupware). Provides CalDAV, CardDAV, and ActiveSync for mail users. Authenticates against the existing PostgreSQL `users` table via a database VIEW. Enabled per-domain in mail settings.
+
+---
+
+## Production Deployment
+
+### Docker Compose (Single Node)
+
+The simplest production deployment runs the entire control plane on a single Docker host.
 
 ```bash
 cd deployments/docker
-
-# Copy environment file
 cp .env.example .env
+# Edit .env to set:
+#   DOMAIN=viswall.example.com
+#   ACME_EMAIL=admin@example.com  (for Let's Encrypt)
+#   JWT_SECRET_KEY=<strong-random-key>
+#   DATABASE_URL=postgresql+asyncpg://viswall:<password>@postgres/viswall
 
-# Start services
 docker-compose up -d
-
-# Access:
-# - Web UI: http://localhost:3000
-# - API: http://localhost:8000
-# - API Docs: http://localhost:8000/docs
-# - Grafana: http://localhost:3001 (admin/admin)
-# - Prometheus: http://localhost:9090
 ```
 
-## 📁 Project Structure
+This starts PostgreSQL, Redis, the API Gateway, Web UI, Nginx (with TLS), Prometheus, Grafana, and SOGo on a single machine. Nginx handles TLS termination and routes traffic to the appropriate backend.
+
+Access points after deployment:
+- Web UI: `https://viswall.example.com`
+- API: `https://viswall.example.com/api/v1`
+- Grafana: `https://viswall.example.com/grafana`
+- SOGo: `https://viswall.example.com/sogo`
+
+### Manager and Agent Nodes (Distributed)
+
+For production networks with multiple edge locations, deploy the manager separately from the agents.
+
+**Manager Node.** Deploy only the control plane services:
+- PostgreSQL + Redis
+- API Gateway + Web UI + Nginx
+- Prometheus + Grafana
+
+The manager node requires only standard Docker networking. No privileged containers or host networking mode is needed.
+
+**Agent Nodes.** Each edge instance runs one or more agents:
+- `firewall-service` — applies iptables/nftables rules
+- `mail-service` — manages Postfix/Dovecot configuration
+- `vpn-service` — configures WireGuard/IPsec/OpenVPN
+
+Agents need:
+- `privileged: true` (for iptables/netfilter access)
+- `network_mode: host` (for direct network interface manipulation)
+- Reachability to the manager's API endpoint over HTTPS
+- A unique API key per instance, stored in the manager database
+
+Agents register with the manager through the heartbeat endpoint. The manager responds with the current configuration version; if the version differs from what the agent has applied, the agent pulls the full configuration and applies it locally.
+
+**Ansible Playbooks.** For organizations managing many instances, Ansible playbooks in `deployments/ansible/` automate manager and agent node deployment. The playbooks install Docker, generate TLS certificates, configure Nginx, and start the appropriate services based on the target node's role (`manager` or `agent`).
+
+### Scaling Considerations
+
+**Database.** PostgreSQL can be replaced with a managed instance (AWS RDS, Google Cloud SQL, Azure Database) by updating `DATABASE_URL`. Run migrations from any host with network access to the database:
+
+```bash
+cd services/api-gateway
+python -m alembic upgrade head
+```
+
+**API Gateway.** The API Gateway is stateless except for database connections. Scale horizontally by running multiple API Gateway containers behind Nginx and using a shared PostgreSQL instance.
+
+**Metrics Storage.** Metrics snapshots accumulate over time. For long-term retention, configure PostgreSQL partitioning on the `metric_snapshots` table or export Prometheus data to an external time-series database.
+
+**Agent Resilience.** Agents cache their last-applied configuration locally. If the manager is temporarily unreachable, agents continue enforcing the last known ruleset and retry heartbeats with exponential backoff.
+
+---
+
+## Quick Start
+
+```bash
+cd deployments/docker
+cp .env.example .env
+# Edit .env with your domain and secrets
+docker-compose up -d
+```
+
+Then open `https://localhost` (or your configured domain) and log in with the default admin credentials.
+
+---
+
+## Project Structure
 
 ```
 viswall/
 ├── services/
-│   ├── api-gateway/      # Central management API (FastAPI)
-│   │   ├── routers/      # API routes per domain
-│   │   ├── metrics_collector.py  # Background metrics collection task
-│   │   ├── migrations/   # Alembic database migrations
-│   │   └── tests/        # pytest test suite
-│   ├── firewall-service/ # Firewall agent (wired into docker-compose, commented by default)
-│   ├── mail-service/     # Mail agent (wired into docker-compose, commented by default)
-│   └── vpn-service/      # VPN agent (wired into docker-compose, commented by default)
-├── web-ui/               # React 18 + TypeScript frontend
-│   ├── src/pages/        # Page components
-│   ├── src/components/   # Reusable UI components
-│   ├── src/hooks/        # TanStack Query API hooks
-│   └── src/types/        # TypeScript type definitions
-├── shared/               # Shared Python modules
-│   ├── models.py         # SQLAlchemy ORM models (all tables)
-│   ├── schemas.py        # Pydantic schemas (all schemas)
-│   ├── database.py       # Async engine + Alembic integration
-│   ├── security.py       # JWT auth utilities
-│   └── audit_logger.py   # Audit logging helper
+│   ├── api-gateway/          # FastAPI management API
+│   ├── firewall-service/     # Firewall agent (edge node)
+│   ├── mail-service/         # Mail agent (edge node)
+│   ├── vpn-service/          # VPN agent (edge node)
+│   └── sogo-service/         # SOGo groupware
+├── web-ui/                   # React 18 + TypeScript frontend
+├── shared/                   # Shared Python modules (models, schemas, auth)
+├── sdk/
+│   ├── python/               # Python SDK (viswall-sdk)
+│   ├── typescript/           # TypeScript SDK (@viswall/sdk)
+│   └── cli/                  # CLI tool (viswall-cli)
 ├── deployments/
-│   └── docker/           # Docker Compose configurations
-└── .github/workflows/    # GitHub Actions CI/CD
+│   ├── docker/               # Docker Compose stack
+│   └── ansible/              # Ansible playbooks
+└── .github/workflows/        # CI/CD pipelines
 ```
 
-## ✅ Features
+---
 
-### Implemented
+## SDKs & CLI
 
-- [x] Multi-instance management architecture
-- [x] RBAC with local authentication (admin, superadmin, user, readonly)
-- [x] FastAPI-based REST API with automatic OpenAPI docs
-- [x] Docker deployment with PostgreSQL, Redis, Prometheus, Grafana
-- [x] GitHub Actions CI/CD pipeline (backend + frontend + integration tests)
-- [x] React 18 SPA with full routing
-- [x] Firewall rules CRUD + simulator + test suites
-- [x] Traffic shaping / QoS policies and classes
-- [x] VPN management (WireGuard, IPsec, OpenVPN, L2TP, PPTP) with client configs
-- [x] Mail domain and user management with DKIM/DMARC/SPF toggles
-- [x] Metrics dashboard with Recharts (CPU, memory, disk, mail activity)
-- [x] Metrics collector background job (auto-inserts MetricSnapshot rows)
-- [x] Routing rules (policy-based routing)
-- [x] Audit logging for all CRUD and deploy operations
-- [x] Database migrations with Alembic
-- [x] Settings page with LLM config and theme toggle
-- [x] LDAP/AD authentication with auto-provisioning
-- [x] Service agents wired into docker-compose (firewall, mail, VPN)
-- [x] Grafana provisioned dashboards with Prometheus metrics endpoint
-- [x] Ansible deployment playbooks for manager and agent nodes
-- [x] LLM-based email classification with editable categories (OpenAI/Anthropic/local)
-- [x] Groupware integration (SOGo with CalDAV/CardDAV/ActiveSync via nginx reverse proxy)
-- [x] Python SDK (`viswall-sdk`) with resource-oriented API
-- [x] TypeScript SDK (`@viswall/sdk`) with auto-generated OpenAPI types
-- [x] CLI tool (`viswall-cli`) for scripting and automation
+Viswall provides official SDKs and a command-line tool for automation.
 
-## 📦 SDKs & CLI
-
-### Python SDK
+**Python SDK**
 
 ```bash
-cd sdk/python
-pip install -e ".[dev]"
-python -m pytest tests/ -v
+pip install viswall-sdk
 ```
 
-### TypeScript SDK
-
-```bash
-cd sdk/typescript
-npm install
-npm run generate-types  # Regenerate from OpenAPI spec
-npm run type-check
-npm run test
-npm run build
+```python
+from viswall import ViswallClient
+client = ViswallClient(base_url="https://viswall.example.com", token="jwt")
+instances = client.instances.list()
+client.firewall.create_rule(instance_id=1, name="Allow HTTPS", action="accept", dst_port=443)
 ```
 
-### CLI Tool
+**TypeScript SDK**
 
 ```bash
-cd sdk/cli
-pip install -e ".[dev]" -e ../python
+npm install @viswall/sdk
+```
 
-# Login
+```typescript
+import { ViswallClient } from '@viswall/sdk';
+const client = new ViswallClient({ baseURL: 'https://viswall.example.com', token: 'jwt' });
+const rules = await client.firewall.listRules(1);
+```
+
+**CLI**
+
+```bash
+pip install viswall-cli
 viswall login --url https://viswall.example.com --username admin
-
-# List instances
 viswall instances list
-
-# Create firewall rule
 viswall firewall create --instance-id 1 --name "Allow HTTPS" --action accept --dst-port 443
 ```
 
-## 🔧 Development
+---
+
+## Development
 
 ### Backend
 
 ```bash
 cd services/api-gateway
-python -m venv venv
-source venv/bin/activate
 pip install -r requirements.txt
-
-# Database migrations
-cd services/api-gateway
-python -m alembic upgrade head        # Apply migrations
-python -m alembic revision --autogenerate -m "Description"  # Create new migration
-
-# Run with auto-reload
 export DATABASE_URL="postgresql+asyncpg://viswall:viswall@localhost/viswall"
 export REDIS_URL="redis://localhost:6379/0"
 export JWT_SECRET_KEY="dev-secret-key"
@@ -156,33 +245,34 @@ uvicorn main:app --reload --host 0.0.0.0 --port 8000
 ```bash
 cd web-ui
 npm install
-npm run dev         # Vite dev server on :5173
-npm run type-check  # TypeScript check
-npm run lint        # ESLint
-npm run test:ci     # Vitest
-npm run build       # Production build
+npm run dev
 ```
 
-## 🧪 Testing
+### Testing
 
 ```bash
-# Backend tests
-cd services/api-gateway
-python -m pytest tests/ -v --asyncio-mode=auto
+# Backend
+cd services/api-gateway && python -m pytest tests/ -v --asyncio-mode=auto
 
-# Frontend tests
-cd web-ui
-npm run test:ci
-
-# Full checks (run before committing)
-cd services/api-gateway && python -m pytest tests/ -v
+# Frontend
 cd web-ui && npm run type-check && npm run lint && npm run test:ci && npm run build
+
+# Python SDK
+cd sdk/python && python -m pytest tests/ -v && python -m ruff check viswall/ && python -m mypy viswall/
+
+# TypeScript SDK
+cd sdk/typescript && npm run type-check && npm run test && npm run build
+
+# CLI
+cd sdk/cli && python -m pytest tests/ -v && python -m ruff check viswall_cli/ && python -m mypy viswall_cli/
 ```
-
-## 📄 License
-
-MIT License - See LICENSE file for details.
 
 ---
 
-**Note**: This is a complete rewrite. The legacy PHP codebase in `source/` and `files/` is preserved for reference but not used in the new architecture.
+## License
+
+MIT License
+
+---
+
+**Note**: The `source/` and `files/` directories contain the legacy PHP/Perl/C++ codebase from the original appliance. They are preserved for reference but are not used in the modern architecture.

--- a/deployments/docker/.env.example
+++ b/deployments/docker/.env.example
@@ -20,6 +20,10 @@ LETSENCRYPT_EMAIL=admin@localhost
 # SOGo timezone (e.g., UTC, America/New_York, Europe/Berlin)
 TZ=UTC
 
+# Ollama LLM
+OLLAMA_URL=http://ollama:11434
+OLLAMA_DEFAULT_MODEL=qwen3.5:9b
+
 # Instance API Keys (for connecting agents to api-gateway)
 # INSTANCE_API_KEY=vis_xxxxxxxxxxxxxxxx
 

--- a/deployments/docker/docker-compose.yml
+++ b/deployments/docker/docker-compose.yml
@@ -38,6 +38,7 @@ services:
       REDIS_URL: redis://redis:6379/0
       JWT_SECRET_KEY: ${JWT_SECRET_KEY:-change-me-in-production}
       CORS_ORIGINS: ${CORS_ORIGINS:-https://localhost}
+      OLLAMA_URL: ${OLLAMA_URL:-http://ollama:11434}
     # No direct port binding — accessed via nginx reverse proxy
     depends_on:
       postgres:
@@ -132,6 +133,23 @@ services:
     networks:
       - viswall
 
+  # Ollama LLM (local inference)
+  ollama:
+    image: ollama/ollama:latest
+    volumes:
+      - ollama_data:/root/.ollama
+    # No port binding — accessed internally by api-gateway
+    environment:
+      OLLAMA_HOST: 0.0.0.0:11434
+    networks:
+      - viswall
+    healthcheck:
+      test: ["CMD-SHELL", "curl -f http://localhost:11434/api/tags || exit 1"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 60s
+
   # ============================================================================
   # SERVICE AGENTS (optional — uncomment to run agents in docker-compose)
   # These agents normally run on individual viswall instances.
@@ -183,6 +201,22 @@ services:
   #   depends_on:
   #     - api-gateway
 
+  # Ollama model pull (runs once on startup)
+  ollama-pull:
+    image: curlimages/curl:latest
+    depends_on:
+      ollama:
+        condition: service_healthy
+    command: >
+      sh -c "
+        echo 'Pulling qwen3.5:9b model...' &&
+        curl -X POST http://ollama:11434/api/pull -d '{\"name\": \"qwen3.5:9b\"}' &&
+        echo 'Model pull complete.'
+      "
+    networks:
+      - viswall
+    restart: "no"
+
 volumes:
   postgres_data:
   redis_data:
@@ -190,6 +224,7 @@ volumes:
   grafana_data:
   certbot_data:
   certbot_www:
+  ollama_data:
 
 networks:
   viswall:

--- a/sdk/cli/pyproject.toml
+++ b/sdk/cli/pyproject.toml
@@ -38,6 +38,7 @@ dev = [
     "pytest-httpx>=0.29.0",
     "ruff>=0.1.0",
     "mypy>=1.5.0",
+    "types-PyYAML>=6.0",
 ]
 
 [project.urls]

--- a/services/api-gateway/migrations/versions/d4a8f2e1b3c0_add_llm_provider_registry_tables.py
+++ b/services/api-gateway/migrations/versions/d4a8f2e1b3c0_add_llm_provider_registry_tables.py
@@ -1,0 +1,96 @@
+"""add_llm_provider_registry_tables
+
+Revision ID: d4a8f2e1b3c0
+Revises: 5125192c673e
+Create Date: 2026-04-25 12:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision: str = 'd4a8f2e1b3c0'
+down_revision: Union[str, None] = '5125192c673e'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # llm_providers
+    op.create_table(
+        'llm_providers',
+        sa.Column('id', sa.Integer(), nullable=False),
+        sa.Column('name', sa.String(length=100), nullable=False),
+        sa.Column('provider_type', sa.String(length=20), nullable=False),
+        sa.Column('base_url', sa.String(length=500), nullable=True),
+        sa.Column('api_key', sa.String(length=500), nullable=True),
+        sa.Column('is_enabled', sa.Boolean(), nullable=True),
+        sa.Column('is_default', sa.Boolean(), nullable=True),
+        sa.Column('created_at', sa.DateTime(), nullable=True),
+        sa.Column('updated_at', sa.DateTime(), nullable=True),
+        sa.PrimaryKeyConstraint('id')
+    )
+
+    # llm_models
+    op.create_table(
+        'llm_models',
+        sa.Column('id', sa.Integer(), nullable=False),
+        sa.Column('provider_id', sa.Integer(), nullable=False),
+        sa.Column('name', sa.String(length=100), nullable=False),
+        sa.Column('display_name', sa.String(length=255), nullable=True),
+        sa.Column('description', sa.Text(), nullable=True),
+        sa.Column('max_tokens', sa.Integer(), nullable=True),
+        sa.Column('supports_vision', sa.Boolean(), nullable=True),
+        sa.Column('is_enabled', sa.Boolean(), nullable=True),
+        sa.Column('created_at', sa.DateTime(), nullable=True),
+        sa.ForeignKeyConstraint(['provider_id'], ['llm_providers.id'], ondelete='CASCADE'),
+        sa.PrimaryKeyConstraint('id')
+    )
+
+    # llm_use_case_configs
+    op.create_table(
+        'llm_use_case_configs',
+        sa.Column('id', sa.Integer(), nullable=False),
+        sa.Column('use_case', sa.String(length=50), nullable=False),
+        sa.Column('provider_id', sa.Integer(), nullable=True),
+        sa.Column('model_id', sa.Integer(), nullable=True),
+        sa.Column('temperature', sa.Float(), nullable=True),
+        sa.Column('max_tokens', sa.Integer(), nullable=True),
+        sa.Column('top_p', sa.Float(), nullable=True),
+        sa.Column('system_prompt', sa.Text(), nullable=True),
+        sa.Column('timeout_seconds', sa.Integer(), nullable=True),
+        sa.Column('is_enabled', sa.Boolean(), nullable=True),
+        sa.Column('created_at', sa.DateTime(), nullable=True),
+        sa.Column('updated_at', sa.DateTime(), nullable=True),
+        sa.ForeignKeyConstraint(['provider_id'], ['llm_providers.id']),
+        sa.ForeignKeyConstraint(['model_id'], ['llm_models.id']),
+        sa.PrimaryKeyConstraint('id'),
+        sa.UniqueConstraint('use_case')
+    )
+
+    # Seed default Ollama provider + qwen3.5:9b model + use-case configs
+    op.execute("""
+        INSERT INTO llm_providers (id, name, provider_type, base_url, is_enabled, is_default, created_at, updated_at)
+        VALUES (1, 'Local Ollama', 'ollama', 'http://ollama:11434', true, true, NOW(), NOW())
+    """)
+
+    op.execute("""
+        INSERT INTO llm_models (id, provider_id, name, display_name, description, max_tokens, is_enabled, created_at)
+        VALUES (1, 1, 'qwen3.5:9b', 'Qwen 3.5 9B', 'Default local model for classification and assistance', 4096, true, NOW())
+    """)
+
+    op.execute("""
+        INSERT INTO llm_use_case_configs (use_case, provider_id, model_id, temperature, max_tokens, system_prompt, timeout_seconds, is_enabled, created_at, updated_at)
+        VALUES
+            ('email_classification', 1, 1, 0.1, 200, 'You are an email classification assistant. Respond only with valid JSON.', 30, true, NOW(), NOW()),
+            ('assistant_chat', 1, 1, 0.3, 500, 'You are a helpful network security assistant.', 30, true, NOW(), NOW()),
+            ('security_audit', 1, 1, 0.2, 1000, 'You are a security audit expert. Analyze configurations for vulnerabilities.', 60, true, NOW(), NOW())
+    """)
+
+
+def downgrade() -> None:
+    op.drop_table('llm_use_case_configs')
+    op.drop_table('llm_models')
+    op.drop_table('llm_providers')

--- a/shared/models.py
+++ b/shared/models.py
@@ -624,3 +624,74 @@ class QoSClass(Base):
 
     # Relationship back to policy
     policy = relationship("QoSPolicy", back_populates="classes")
+
+
+# ============================================================================
+# LLM PROVIDER REGISTRY
+# ============================================================================
+
+
+class LLMProvider(Base):
+    """Configured LLM providers (OpenAI, Anthropic, Ollama, custom)"""
+
+    __tablename__ = "llm_providers"
+
+    id = Column(Integer, primary_key=True)
+    name = Column(String(100), nullable=False)
+    provider_type = Column(String(20), nullable=False)  # openai, anthropic, ollama, custom
+    base_url = Column(String(500), nullable=True)
+    api_key = Column(String(500), nullable=True)
+    is_enabled = Column(Boolean, default=True)
+    is_default = Column(Boolean, default=False)
+    created_at = Column(DateTime, default=datetime.utcnow)
+    updated_at = Column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
+
+    # Relationships
+    models = relationship("LLMModel", back_populates="provider", cascade="all, delete-orphan")
+    use_case_configs = relationship("LLMUseCaseConfig", back_populates="provider")
+
+
+class LLMModel(Base):
+    """Models available per provider"""
+
+    __tablename__ = "llm_models"
+
+    id = Column(Integer, primary_key=True)
+    provider_id = Column(Integer, ForeignKey("llm_providers.id"), nullable=False)
+    name = Column(String(100), nullable=False)  # model identifier, e.g. gpt-4, llama3.2
+    display_name = Column(String(255), nullable=True)
+    description = Column(Text, nullable=True)
+    max_tokens = Column(Integer, nullable=True)
+    supports_vision = Column(Boolean, default=False)
+    is_enabled = Column(Boolean, default=True)
+    created_at = Column(DateTime, default=datetime.utcnow)
+
+    # Relationships
+    provider = relationship("LLMProvider", back_populates="models")
+    use_case_configs = relationship("LLMUseCaseConfig", back_populates="model")
+
+
+class LLMUseCaseConfig(Base):
+    """Per-use-case LLM configuration (email classification, assistant chat, etc.)"""
+
+    __tablename__ = "llm_use_case_configs"
+
+    id = Column(Integer, primary_key=True)
+    use_case = Column(String(50), nullable=False, unique=True)  # email_classification, assistant_chat, security_audit
+    provider_id = Column(Integer, ForeignKey("llm_providers.id"), nullable=True)
+    model_id = Column(Integer, ForeignKey("llm_models.id"), nullable=True)
+
+    # Generation parameters
+    temperature = Column(Float, default=0.3)
+    max_tokens = Column(Integer, default=500)
+    top_p = Column(Float, default=1.0)
+    system_prompt = Column(Text, nullable=True)
+    timeout_seconds = Column(Integer, default=30)
+
+    is_enabled = Column(Boolean, default=True)
+    created_at = Column(DateTime, default=datetime.utcnow)
+    updated_at = Column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
+
+    # Relationships
+    provider = relationship("LLMProvider", back_populates="use_case_configs")
+    model = relationship("LLMModel", back_populates="use_case_configs")

--- a/shared/schemas.py
+++ b/shared/schemas.py
@@ -543,6 +543,123 @@ class LLMConfig(BaseModel):
 
 
 # ============================================================================
+# LLM PROVIDER REGISTRY SCHEMAS
+# ============================================================================
+
+
+class LLMProviderType(str, Enum):
+    OPENAI = "openai"
+    ANTHROPIC = "anthropic"
+    OLLAMA = "ollama"
+    CUSTOM = "custom"
+
+
+class LLMProviderBase(BaseModel):
+    name: str
+    provider_type: LLMProviderType
+    base_url: Optional[str] = None
+    api_key: Optional[str] = None
+    is_enabled: bool = True
+    is_default: bool = False
+
+
+class LLMProviderCreate(LLMProviderBase):
+    pass
+
+
+class LLMProviderUpdate(BaseModel):
+    name: Optional[str] = None
+    provider_type: Optional[LLMProviderType] = None
+    base_url: Optional[str] = None
+    api_key: Optional[str] = None
+    is_enabled: Optional[bool] = None
+    is_default: Optional[bool] = None
+
+
+class LLMProviderResponse(LLMProviderBase):
+    id: int
+    created_at: datetime
+    updated_at: datetime
+
+    class Config:
+        from_attributes = True
+
+
+class LLMModelBase(BaseModel):
+    name: str
+    display_name: Optional[str] = None
+    description: Optional[str] = None
+    max_tokens: Optional[int] = None
+    supports_vision: bool = False
+    is_enabled: bool = True
+
+
+class LLMModelCreate(LLMModelBase):
+    provider_id: int
+
+
+class LLMModelUpdate(BaseModel):
+    name: Optional[str] = None
+    display_name: Optional[str] = None
+    description: Optional[str] = None
+    max_tokens: Optional[int] = None
+    supports_vision: Optional[bool] = None
+    is_enabled: Optional[bool] = None
+
+
+class LLMModelResponse(LLMModelBase):
+    id: int
+    provider_id: int
+    created_at: datetime
+
+    class Config:
+        from_attributes = True
+
+
+class LLMUseCase(str, Enum):
+    EMAIL_CLASSIFICATION = "email_classification"
+    ASSISTANT_CHAT = "assistant_chat"
+    SECURITY_AUDIT = "security_audit"
+
+
+class LLMUseCaseConfigBase(BaseModel):
+    use_case: LLMUseCase
+    provider_id: Optional[int] = None
+    model_id: Optional[int] = None
+    temperature: float = 0.3
+    max_tokens: int = 500
+    top_p: float = 1.0
+    system_prompt: Optional[str] = None
+    timeout_seconds: int = 30
+    is_enabled: bool = True
+
+
+class LLMUseCaseConfigCreate(LLMUseCaseConfigBase):
+    pass
+
+
+class LLMUseCaseConfigUpdate(BaseModel):
+    use_case: Optional[LLMUseCase] = None
+    provider_id: Optional[int] = None
+    model_id: Optional[int] = None
+    temperature: Optional[float] = None
+    max_tokens: Optional[int] = None
+    top_p: Optional[float] = None
+    system_prompt: Optional[str] = None
+    timeout_seconds: Optional[int] = None
+    is_enabled: Optional[bool] = None
+
+
+class LLMUseCaseConfigResponse(LLMUseCaseConfigBase):
+    id: int
+    created_at: datetime
+    updated_at: datetime
+
+    class Config:
+        from_attributes = True
+
+
+# ============================================================================
 # VPN SCHEMAS - Multi-Protocol Support
 # ============================================================================
 


### PR DESCRIPTION
## Summary

Part A of the modular LLM infrastructure initiative. Adds Ollama as a default containerized LLM and establishes a normalized database schema for provider/model/use-case configuration.

### Docker Infrastructure
- **Ollama service** (`ollama/ollama:latest`) with internal network access only
- **`ollama-pull` init container** that pre-pulls `qwen3.5:9b` after Ollama is healthy
- **Persistent volume** `ollama_data` for model caching
- **`OLLAMA_URL`** passed to `api-gateway` for internal discovery

### Database Schema
Three new tables replace the ad-hoc JSON blob approach:

| Table | Purpose |
|-------|---------|
| `llm_providers` | Provider configs (name, type, base_url, api_key, enabled, default) |
| `llm_models` | Models per provider (identifier, display name, max_tokens, vision support) |
| `llm_use_case_configs` | Maps use cases to provider+model (temperature, max_tokens, system_prompt, timeout) |

**Seed data** (created automatically on migration):
- Provider: "Local Ollama" → `http://ollama:11434`
- Model: `qwen3.5:9b` (4096 max tokens)
- Use-case configs:
  - `email_classification` (temp 0.1, 200 tokens)
  - `assistant_chat` (temp 0.3, 500 tokens)
  - `security_audit` (temp 0.2, 1000 tokens)

### Pydantic Schemas
Added `LLMProvider*`, `LLMModel*`, `LLMUseCaseConfig*` schema families to `shared/schemas.py`.

### Notes
- Per-domain `mail_domains.llm_config` JSON is **not removed yet** — deprecation happens in PR #B when the backend switches to the registry.
- API key encryption deferred to a future security-focused PR.