### PR TITLE
feat(infra): enable IPv6 in Docker Compose and nginx

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,102 @@ python -m alembic upgrade head
 
 ---
 
+## Selective Component Deployment
+
+You do not need to run the entire stack. The manager services are stateless except for PostgreSQL and Redis, and agents are optional depending on which capabilities you need. Use explicit service names with `docker-compose up -d` or create an override file (`docker-compose.override.yml`) to customize the deployment.
+
+### Manager Only (No Agents, No Monitoring)
+
+Run just the control plane — API, web UI, database, and reverse proxy. Use this when you will deploy agents on separate edge nodes.
+
+```bash
+cd deployments/docker
+docker-compose up -d postgres redis api-gateway web-ui nginx
+```
+
+Services started: PostgreSQL, Redis, API Gateway, Web UI, Nginx.
+
+### Minimal Firewall Appliance
+
+Run the manager plus the firewall agent on a single host. The firewall agent requires `privileged: true` and `network_mode: host`.
+
+Uncomment the `firewall-service` block in `docker-compose.yml`, then start:
+
+```bash
+docker-compose up -d postgres redis api-gateway web-ui nginx firewall-service
+```
+
+> **Note:** The firewall agent manipulates the host's netfilter tables. Only run this on a dedicated appliance or VM.
+
+### Mail Server with Groupware
+
+Run the manager, SOGo groupware, Ollama (for LLM email classification), and the mail agent on a single host.
+
+Uncomment the `mail-service` block in `docker-compose.yml`, then start:
+
+```bash
+docker-compose up -d postgres redis api-gateway web-ui nginx sogo ollama ollama-pull mail-service
+```
+
+Exposed ports: `25`, `465`, `587` (SMTP), `143`, `993` (IMAP). SOGo is available at `/sogo`.
+
+### VPN Server
+
+Run the manager plus the VPN agent on a single host. The VPN agent requires `privileged: true` and `network_mode: host`.
+
+Uncomment the `vpn-service` block in `docker-compose.yml`, then start:
+
+```bash
+docker-compose up -d postgres redis api-gateway web-ui nginx vpn-service
+```
+
+> **Note:** The VPN agent creates WireGuard/IPsec interfaces on the host network namespace.
+
+### Full Stack (Single Node)
+
+Run everything on one machine — manager, all agents, monitoring, and LLM inference. This is useful for homelabs and small offices.
+
+Uncomment all agent blocks in `docker-compose.yml`, then start the full stack:
+
+```bash
+docker-compose up -d
+```
+
+### Using Compose Override Files
+
+For cleaner selective deployments, create a `docker-compose.override.yml` instead of editing the main file. For example, to deploy a mail-only node:
+
+```yaml
+# deployments/docker/docker-compose.override.yml
+services:
+  mail-service:
+    build:
+      context: ../..
+      dockerfile: services/mail-service/Dockerfile
+    environment:
+      DATABASE_URL: postgresql+asyncpg://viswall:${DB_PASSWORD:-viswall}@postgres/viswall
+      REDIS_URL: redis://redis:6379/1
+    privileged: true
+    ports:
+      - "25:25"
+      - "465:465"
+      - "587:587"
+      - "143:143"
+      - "993:993"
+    networks:
+      - viswall
+```
+
+Then run:
+
+```bash
+docker-compose up -d
+```
+
+Docker Compose automatically merges `docker-compose.yml` and `docker-compose.override.yml`.
+
+---
+
 ## Quick Start
 
 ```bash

--- a/deployments/docker/.env.example
+++ b/deployments/docker/.env.example
@@ -26,7 +26,7 @@ OLLAMA_DEFAULT_MODEL=qwen3.5:9b
 
 # IPv6 Configuration
 # ULA subnet for the Docker bridge network. Set to empty to disable IPv6.
-IPV6_SUBNET=fd00:viswall::/64
+IPV6_SUBNET=fd00:42::/64
 
 # Instance API Keys (for connecting agents to api-gateway)
 # INSTANCE_API_KEY=vis_xxxxxxxxxxxxxxxx

--- a/deployments/docker/.env.example
+++ b/deployments/docker/.env.example
@@ -24,6 +24,10 @@ TZ=UTC
 OLLAMA_URL=http://ollama:11434
 OLLAMA_DEFAULT_MODEL=qwen3.5:9b
 
+# IPv6 Configuration
+# ULA subnet for the Docker bridge network. Set to empty to disable IPv6.
+IPV6_SUBNET=fd00:viswall::/64
+
 # Instance API Keys (for connecting agents to api-gateway)
 # INSTANCE_API_KEY=vis_xxxxxxxxxxxxxxxx
 

--- a/deployments/docker/docker-compose.yml
+++ b/deployments/docker/docker-compose.yml
@@ -232,4 +232,4 @@ networks:
     enable_ipv6: true
     ipam:
       config:
-        - subnet: ${IPV6_SUBNET:-fd00:viswall::/64}
+        - subnet: ${IPV6_SUBNET:-fd00:42::/64}

--- a/deployments/docker/docker-compose.yml
+++ b/deployments/docker/docker-compose.yml
@@ -140,7 +140,7 @@ services:
       - ollama_data:/root/.ollama
     # No port binding — accessed internally by api-gateway
     environment:
-      OLLAMA_HOST: 0.0.0.0:11434
+      OLLAMA_HOST: ':11434'
     networks:
       - viswall
     healthcheck:
@@ -229,3 +229,7 @@ volumes:
 networks:
   viswall:
     driver: bridge
+    enable_ipv6: true
+    ipam:
+      config:
+        - subnet: ${IPV6_SUBNET:-fd00:viswall::/64}

--- a/deployments/docker/nginx/nginx.conf.template
+++ b/deployments/docker/nginx/nginx.conf.template
@@ -46,6 +46,7 @@ http {
     # HTTP server - redirect to HTTPS
     server {
         listen 80;
+        listen [::]:80;
         server_name _;
 
         # Let's Encrypt challenge
@@ -62,6 +63,7 @@ http {
     # HTTPS server
     server {
         listen 443 ssl http2;
+        listen [::]:443 ssl http2;
         server_name _;
 
         # SSL configuration


### PR DESCRIPTION
## Summary

Enables IPv6 at the container network and reverse proxy layer as the first step toward full dual-stack support.

## Changes

- **Docker Compose** — Adds `enable_ipv6: true` and a configurable ULA subnet (`fd00:viswall::/64`) to the `viswall` bridge network
- **nginx** — Adds `listen [::]:80` and `listen [::]:443 ssl http2` directives for dual-stack HTTP/HTTPS
- **Ollama** — Changes `OLLAMA_HOST` from `0.0.0.0:11434` to `:11434` so it binds to all interfaces (IPv4 + IPv6)
- **Environment** — Adds `IPV6_SUBNET` to `.env.example`

## Validation

```bash
cd deployments/docker
IPV6_SUBNET="fd00:viswall::/64" docker compose config
```

Renders correct IPv6 network configuration.

## Related

Part of the IPv6 support series: PR #1 → #2 → #3 → #4 → #5 → #6