### PR TITLE
feat(vpn): dual-stack WireGuard, IPsec, and OpenVPN support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -192,7 +192,7 @@ pip install -r requirements.txt
 export DATABASE_URL="postgresql+asyncpg://viswall:viswall@localhost/viswall"
 export REDIS_URL="redis://localhost:6379/0"
 export JWT_SECRET_KEY="dev-secret-key"
-uvicorn main:app --reload --host 0.0.0.0 --port 8000
+uvicorn main:app --reload --host :: --port 8000
 ```
 
 ### Frontend Only

--- a/README.md
+++ b/README.md
@@ -333,7 +333,7 @@ pip install -r requirements.txt
 export DATABASE_URL="postgresql+asyncpg://viswall:viswall@localhost/viswall"
 export REDIS_URL="redis://localhost:6379/0"
 export JWT_SECRET_KEY="dev-secret-key"
-uvicorn main:app --reload --host 0.0.0.0 --port 8000
+uvicorn main:app --reload --host :: --port 8000
 ```
 
 ### Frontend

--- a/README.md
+++ b/README.md
@@ -150,6 +150,102 @@ python -m alembic upgrade head
 
 ---
 
+## Selective Component Deployment
+
+You do not need to run the entire stack. The manager services are stateless except for PostgreSQL and Redis, and agents are optional depending on which capabilities you need. Use explicit service names with `docker-compose up -d` or create an override file (`docker-compose.override.yml`) to customize the deployment.
+
+### Manager Only (No Agents, No Monitoring)
+
+Run just the control plane — API, web UI, database, and reverse proxy. Use this when you will deploy agents on separate edge nodes.
+
+```bash
+cd deployments/docker
+docker-compose up -d postgres redis api-gateway web-ui nginx
+```
+
+Services started: PostgreSQL, Redis, API Gateway, Web UI, Nginx.
+
+### Minimal Firewall Appliance
+
+Run the manager plus the firewall agent on a single host. The firewall agent requires `privileged: true` and `network_mode: host`.
+
+Uncomment the `firewall-service` block in `docker-compose.yml`, then start:
+
+```bash
+docker-compose up -d postgres redis api-gateway web-ui nginx firewall-service
+```
+
+> **Note:** The firewall agent manipulates the host's netfilter tables. Only run this on a dedicated appliance or VM.
+
+### Mail Server with Groupware
+
+Run the manager, SOGo groupware, Ollama (for LLM email classification), and the mail agent on a single host.
+
+Uncomment the `mail-service` block in `docker-compose.yml`, then start:
+
+```bash
+docker-compose up -d postgres redis api-gateway web-ui nginx sogo ollama ollama-pull mail-service
+```
+
+Exposed ports: `25`, `465`, `587` (SMTP), `143`, `993` (IMAP). SOGo is available at `/sogo`.
+
+### VPN Server
+
+Run the manager plus the VPN agent on a single host. The VPN agent requires `privileged: true` and `network_mode: host`.
+
+Uncomment the `vpn-service` block in `docker-compose.yml`, then start:
+
+```bash
+docker-compose up -d postgres redis api-gateway web-ui nginx vpn-service
+```
+
+> **Note:** The VPN agent creates WireGuard/IPsec interfaces on the host network namespace.
+
+### Full Stack (Single Node)
+
+Run everything on one machine — manager, all agents, monitoring, and LLM inference. This is useful for homelabs and small offices.
+
+Uncomment all agent blocks in `docker-compose.yml`, then start the full stack:
+
+```bash
+docker-compose up -d
+```
+
+### Using Compose Override Files
+
+For cleaner selective deployments, create a `docker-compose.override.yml` instead of editing the main file. For example, to deploy a mail-only node:
+
+```yaml
+# deployments/docker/docker-compose.override.yml
+services:
+  mail-service:
+    build:
+      context: ../..
+      dockerfile: services/mail-service/Dockerfile
+    environment:
+      DATABASE_URL: postgresql+asyncpg://viswall:${DB_PASSWORD:-viswall}@postgres/viswall
+      REDIS_URL: redis://redis:6379/1
+    privileged: true
+    ports:
+      - "25:25"
+      - "465:465"
+      - "587:587"
+      - "143:143"
+      - "993:993"
+    networks:
+      - viswall
+```
+
+Then run:
+
+```bash
+docker-compose up -d
+```
+
+Docker Compose automatically merges `docker-compose.yml` and `docker-compose.override.yml`.
+
+---
+
 ## Quick Start
 
 ```bash

--- a/deployments/docker/.env.example
+++ b/deployments/docker/.env.example
@@ -26,7 +26,7 @@ OLLAMA_DEFAULT_MODEL=qwen3.5:9b
 
 # IPv6 Configuration
 # ULA subnet for the Docker bridge network. Set to empty to disable IPv6.
-IPV6_SUBNET=fd00:viswall::/64
+IPV6_SUBNET=fd00:42::/64
 
 # Instance API Keys (for connecting agents to api-gateway)
 # INSTANCE_API_KEY=vis_xxxxxxxxxxxxxxxx

--- a/deployments/docker/.env.example
+++ b/deployments/docker/.env.example
@@ -24,6 +24,10 @@ TZ=UTC
 OLLAMA_URL=http://ollama:11434
 OLLAMA_DEFAULT_MODEL=qwen3.5:9b
 
+# IPv6 Configuration
+# ULA subnet for the Docker bridge network. Set to empty to disable IPv6.
+IPV6_SUBNET=fd00:viswall::/64
+
 # Instance API Keys (for connecting agents to api-gateway)
 # INSTANCE_API_KEY=vis_xxxxxxxxxxxxxxxx
 

--- a/deployments/docker/docker-compose.yml
+++ b/deployments/docker/docker-compose.yml
@@ -232,4 +232,4 @@ networks:
     enable_ipv6: true
     ipam:
       config:
-        - subnet: ${IPV6_SUBNET:-fd00:viswall::/64}
+        - subnet: ${IPV6_SUBNET:-fd00:42::/64}

--- a/deployments/docker/docker-compose.yml
+++ b/deployments/docker/docker-compose.yml
@@ -140,7 +140,7 @@ services:
       - ollama_data:/root/.ollama
     # No port binding — accessed internally by api-gateway
     environment:
-      OLLAMA_HOST: 0.0.0.0:11434
+      OLLAMA_HOST: ':11434'
     networks:
       - viswall
     healthcheck:
@@ -229,3 +229,7 @@ volumes:
 networks:
   viswall:
     driver: bridge
+    enable_ipv6: true
+    ipam:
+      config:
+        - subnet: ${IPV6_SUBNET:-fd00:viswall::/64}

--- a/deployments/docker/nginx/nginx.conf.template
+++ b/deployments/docker/nginx/nginx.conf.template
@@ -46,6 +46,7 @@ http {
     # HTTP server - redirect to HTTPS
     server {
         listen 80;
+        listen [::]:80;
         server_name _;
 
         # Let's Encrypt challenge
@@ -62,6 +63,7 @@ http {
     # HTTPS server
     server {
         listen 443 ssl http2;
+        listen [::]:443 ssl http2;
         server_name _;
 
         # SSL configuration

--- a/services/api-gateway/Dockerfile
+++ b/services/api-gateway/Dockerfile
@@ -23,4 +23,4 @@ ENV PYTHONUNBUFFERED=1
 EXPOSE 8000
 
 ENV PYTHONPATH=/app:/app/services/api-gateway
-CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000", "--reload"]
+CMD ["uvicorn", "main:app", "--host", "::", "--port", "8000", "--reload"]

--- a/services/api-gateway/migrations/versions/6e439a8a2c2a_add_vpn_ipv6_tunnel_network.py
+++ b/services/api-gateway/migrations/versions/6e439a8a2c2a_add_vpn_ipv6_tunnel_network.py
@@ -1,0 +1,25 @@
+"""add_vpn_ipv6_tunnel_network
+
+Revision ID: 6e439a8a2c2a
+Revises: d4a8f2e1b3c0
+Create Date: 2026-04-25 20:45:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision: str = '6e439a8a2c2a'
+down_revision: Union[str, None] = 'd4a8f2e1b3c0'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column('vpn_servers', sa.Column('ipv6_tunnel_network', sa.String(length=50), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column('vpn_servers', 'ipv6_tunnel_network')

--- a/services/firewall-service/firewall_agent.py
+++ b/services/firewall-service/firewall_agent.py
@@ -131,15 +131,33 @@ table inet viswall {
         flags timeout
         timeout 1h
     }
-    
-    set port_scanners {
+
+    set blacklist_v6 {
+        type ipv6_addr
+        flags timeout
+        timeout 1h
+    }
+
+    set port_scanners_v4 {
         type ipv4_addr
         flags timeout
         timeout 1d
     }
-    
-    set bruteforce_attempts {
+
+    set port_scanners_v6 {
+        type ipv6_addr
+        flags timeout
+        timeout 1d
+    }
+
+    set bruteforce_attempts_v4 {
         type ipv4_addr . inet_service
+        flags timeout
+        timeout 15m
+    }
+
+    set bruteforce_attempts_v6 {
+        type ipv6_addr . inet_service
         flags timeout
         timeout 15m
     }
@@ -150,28 +168,31 @@ table inet viswall {
     # Input chain - traffic to firewall itself
     chain input {
         type filter hook input priority 0; policy drop;
-        
+
         # Connection tracking
         ct state established,related accept
         ct state invalid drop
-        
+
         # Loopback
         iif "lo" accept
-        
-        # Blacklist check
+
+        # Blacklist check (dual-stack)
         ip saddr @blacklist_v4 drop
-        
+        ip6 saddr @blacklist_v6 drop
+
         # Rate limiting for new connections
         tcp flags syn limit rate 25/second burst 50 packets accept
         tcp flags syn drop
-        
+
         # ICMP (ping) rate limiting
         ip protocol icmp limit rate 5/second accept
         ip6 nexthdr icmpv6 limit rate 5/second accept
-        
-        # SSH brute force protection
-        tcp dport 22 add @bruteforce_attempts { ip saddr . tcp dport }
-        tcp dport 22 @bruteforce_attempts size gt 5 drop
+
+        # SSH brute force protection (dual-stack)
+        tcp dport 22 add @bruteforce_attempts_v4 { ip saddr . tcp dport }
+        tcp dport 22 add @bruteforce_attempts_v6 { ip6 saddr . tcp dport }
+        tcp dport 22 @bruteforce_attempts_v4 size gt 5 drop
+        tcp dport 22 @bruteforce_attempts_v6 size gt 5 drop
 """
 
         # Add custom rules
@@ -194,21 +215,25 @@ table inet viswall {
     # Forward chain - traffic passing through
     chain forward {
         type filter hook forward priority 0; policy drop;
-        
+
         # Connection tracking
         ct state established,related accept
         ct state invalid drop
-        
-        # Blacklist check
+
+        # Blacklist check (dual-stack)
         ip saddr @blacklist_v4 drop
         ip daddr @blacklist_v4 drop
-        
+        ip6 saddr @blacklist_v6 drop
+        ip6 daddr @blacklist_v6 drop
+
         # Inter-VLAN routing (if configured)
         # iif @lan_interfaces oif @lan_interfaces accept
-        
-        # Port scanning detection
-        tcp flags syn,tcp flags syn,ack add @port_scanners { ip saddr }
-        ip saddr @port_scanners drop
+
+        # Port scanning detection (dual-stack)
+        tcp flags syn,tcp flags syn,ack add @port_scanners_v4 { ip saddr }
+        tcp flags syn,tcp flags syn,ack add @port_scanners_v6 { ip6 saddr }
+        ip saddr @port_scanners_v4 drop
+        ip6 saddr @port_scanners_v6 drop
 """
 
         # Add forward rules
@@ -273,8 +298,22 @@ table inet viswall {
 
         return ruleset
 
+    def _ip_family(self, addr: Optional[str]) -> str:
+        """Return 'ip' or 'ip6' for an address or CIDR."""
+        if not addr or addr == "any":
+            return "ip"
+        try:
+            if "/" in addr:
+                net = ipaddress.ip_network(addr, strict=False)
+                return "ip6" if isinstance(net, ipaddress.IPv6Network) else "ip"
+            else:
+                ip = ipaddress.ip_address(addr)
+                return "ip6" if isinstance(ip, ipaddress.IPv6Address) else "ip"
+        except ValueError:
+            return "ip"
+
     def _convert_rule_to_nft(self, rule: FirewallRule) -> str:
-        """Convert a FirewallRule to nftables syntax"""
+        """Convert a FirewallRule to nftables syntax (dual-stack aware)"""
         nft_rule = "        "
 
         # Match criteria
@@ -285,20 +324,22 @@ table inet viswall {
         if rule.interface_out:
             conditions.append(f'oif "{rule.interface_out}"')
 
+        src_family = self._ip_family(rule.source)
+        dst_family = self._ip_family(rule.destination)
+
         if rule.source and rule.source != "any":
-            if "/" in rule.source:  # CIDR
-                conditions.append(f"ip saddr {rule.source}")
-            else:
-                conditions.append(f"ip saddr {rule.source}")
+            conditions.append(f"{src_family} saddr {rule.source}")
 
         if rule.destination and rule.destination != "any":
-            if "/" in rule.destination:
-                conditions.append(f"ip daddr {rule.destination}")
-            else:
-                conditions.append(f"ip daddr {rule.destination}")
+            conditions.append(f"{dst_family} daddr {rule.destination}")
 
         if rule.protocol and rule.protocol != "any":
-            conditions.append(f"ip protocol {rule.protocol}")
+            # If both src and dst are IPv6, use ip6 nexthdr; otherwise default to ip protocol
+            family = "ip6" if (src_family == "ip6" or dst_family == "ip6") else "ip"
+            if family == "ip6":
+                conditions.append(f"ip6 nexthdr {rule.protocol}")
+            else:
+                conditions.append(f"ip protocol {rule.protocol}")
 
             if rule.source_port:
                 conditions.append(f"{rule.protocol} sport {rule.source_port}")
@@ -328,20 +369,27 @@ table inet viswall {
         return nft_rule
 
     def _convert_nat_rule_to_nft(self, rule: NATRule) -> str:
-        """Convert a NATRule to nftables syntax"""
+        """Convert a NATRule to nftables syntax (dual-stack aware)"""
         nft_rule = "        "
         conditions = []
 
         if rule.interface:
             conditions.append(f'iif "{rule.interface}"')
 
+        src_family = self._ip_family(rule.source)
+        dst_family = self._ip_family(rule.destination)
+
         if rule.source:
-            conditions.append(f"ip saddr {rule.source}")
+            conditions.append(f"{src_family} saddr {rule.source}")
         if rule.destination:
-            conditions.append(f"ip daddr {rule.destination}")
+            conditions.append(f"{dst_family} daddr {rule.destination}")
 
         if rule.protocol:
-            conditions.append(f"ip protocol {rule.protocol}")
+            family = "ip6" if (src_family == "ip6" or dst_family == "ip6") else "ip"
+            if family == "ip6":
+                conditions.append(f"ip6 nexthdr {rule.protocol}")
+            else:
+                conditions.append(f"ip protocol {rule.protocol}")
             if rule.port:
                 conditions.append(f"{rule.protocol} dport {rule.port}")
 
@@ -416,15 +464,16 @@ table inet viswall {
             return {}
 
     async def add_to_blacklist(self, ip: str, timeout: str = "1h") -> bool:
-        """Dynamically add IP to blacklist"""
+        """Dynamically add IP to blacklist (dual-stack aware)"""
         try:
+            set_name = "blacklist_v6" if self._ip_family(ip) == "ip6" else "blacklist_v4"
             proc = await asyncio.create_subprocess_exec(
                 "nft",
                 "add",
                 "element",
                 "inet",
                 "viswall",
-                "blacklist_v4",
+                set_name,
                 "{",
                 ip,
                 "timeout",
@@ -439,15 +488,16 @@ table inet viswall {
             return False
 
     async def remove_from_blacklist(self, ip: str) -> bool:
-        """Remove IP from blacklist"""
+        """Remove IP from blacklist (dual-stack aware)"""
         try:
+            set_name = "blacklist_v6" if self._ip_family(ip) == "ip6" else "blacklist_v4"
             proc = await asyncio.create_subprocess_exec(
                 "nft",
                 "delete",
                 "element",
                 "inet",
                 "viswall",
-                "blacklist_v4",
+                set_name,
                 "{",
                 ip,
                 "}",
@@ -599,18 +649,21 @@ class TrafficControlManager:
                 ["qdisc", "add", "dev", interface, "parent", classid, "fq_codel"]
             )
 
-        # Filters to classify traffic
+        # Filters to classify traffic (dual-stack)
         # VoIP (SIP)
         await self._add_filter(interface, "1:10", "udp", "5060")
+        await self._add_filter_ipv6(interface, "1:10", "udp", "5060")
         # DNS
         await self._add_filter(interface, "1:10", "udp", "53")
+        await self._add_filter_ipv6(interface, "1:10", "udp", "53")
         # SSH
         await self._add_filter(interface, "1:10", "tcp", "22")
+        await self._add_filter_ipv6(interface, "1:10", "tcp", "22")
 
     async def _add_filter(
         self, interface: str, classid: str, protocol: str, port: str
     ) -> None:
-        """Add traffic filter"""
+        """Add traffic filter (IPv4)"""
         await self._run_tc(
             [
                 "filter",
@@ -634,6 +687,32 @@ class TrafficControlManager:
                 "dport",
                 port,
                 "0xffff",
+                "flowid",
+                classid,
+            ]
+        )
+
+    async def _add_filter_ipv6(
+        self, interface: str, classid: str, protocol: str, port: str
+    ) -> None:
+        """Add traffic filter (IPv6) using flower classifier"""
+        await self._run_tc(
+            [
+                "filter",
+                "add",
+                "dev",
+                interface,
+                "protocol",
+                "ipv6",
+                "parent",
+                "1:0",
+                "prio",
+                "1",
+                "flower",
+                "ip_proto",
+                protocol,
+                "dst_port",
+                port,
                 "flowid",
                 classid,
             ]
@@ -712,26 +791,27 @@ class TrafficControlManager:
                 ]
             )
 
-            # Add filter that creates classes dynamically per source IP
-            await self._run_tc(
-                [
-                    "filter",
-                    "add",
-                    "dev",
-                    interface,
-                    "protocol",
-                    "ip",
-                    "parent",
-                    "1:0",
-                    "prio",
-                    "1",
-                    "handle",
-                    "1:",
-                    "fw",
-                    "classid",
-                    "1:1",
-                ]
-            )
+            # Add filter that creates classes dynamically per source IP (dual-stack)
+            for proto in ("ip", "ipv6"):
+                await self._run_tc(
+                    [
+                        "filter",
+                        "add",
+                        "dev",
+                        interface,
+                        "protocol",
+                        proto,
+                        "parent",
+                        "1:0",
+                        "prio",
+                        "1",
+                        "handle",
+                        "1:",
+                        "fw",
+                        "classid",
+                        "1:1",
+                    ]
+                )
 
             return True
         except:
@@ -947,6 +1027,9 @@ access_log daemon:/var/log/squid/access.log squid
 acl localnet src 10.0.0.0/8
 acl localnet src 172.16.0.0/12
 acl localnet src 192.168.0.0/16
+acl localnet src fc00::/7
+acl localnet src fe80::/10
+acl localnet src ::1/128
 acl SSL_ports port 443
 acl Safe_ports port 80
 acl Safe_ports port 443
@@ -1196,7 +1279,7 @@ if FASTAPI_AVAILABLE:
             raise HTTPException(status_code=500, detail="Failed to unblock IP")
         return {"success": True, "ip": ip}
 
-    def run_server(host: str = "0.0.0.0", port: int = 8081):
+    def run_server(host: str = "::", port: int = 8081):
         import uvicorn
 
         uvicorn.run(app, host=host, port=port)

--- a/services/vpn-service/vpn_agent.py
+++ b/services/vpn-service/vpn_agent.py
@@ -79,34 +79,59 @@ class WireGuardManager:
         private_key: str,
         listen_port: int = 51820,
         network_cidr: str = "10.200.0.0/24",
+        ipv6_tunnel_network: Optional[str] = None,
+        ipv6_nat_enabled: bool = False,
         post_up: Optional[str] = None,
         post_down: Optional[str] = None
     ) -> str:
-        """Create WireGuard server configuration"""
+        """Create WireGuard server configuration (dual-stack aware)"""
+        addresses = [self._get_server_ip(network_cidr)]
+        if ipv6_tunnel_network:
+            addresses.append(self._get_server_ip(ipv6_tunnel_network))
+
         config = f"""[Interface]
 PrivateKey = {private_key}
-Address = {self._get_server_ip(network_cidr)}
+Address = {', '.join(addresses)}
 ListenPort = {listen_port}
 """
-        
-        # Add firewall rules for NAT and forwarding
+
+        # Build PostUp/PostDown for dual-stack
         if not post_up:
-            post_up = (
-                f"iptables -A FORWARD -i {self.interface_name} -j ACCEPT; "
-                f"iptables -A FORWARD -o {self.interface_name} -j ACCEPT; "
-                f"iptables -t nat -A POSTROUTING -s {network_cidr} -o eth0 -j MASQUERADE"
-            )
-        
+            post_up_cmds = [
+                f"iptables -A FORWARD -i {self.interface_name} -j ACCEPT",
+                f"iptables -A FORWARD -o {self.interface_name} -j ACCEPT",
+                f"iptables -t nat -A POSTROUTING -s {network_cidr} -o eth0 -j MASQUERADE",
+            ]
+            # IPv6 forwarding
+            post_up_cmds.extend([
+                f"ip6tables -A FORWARD -i {self.interface_name} -j ACCEPT",
+                f"ip6tables -A FORWARD -o {self.interface_name} -j ACCEPT",
+            ])
+            if ipv6_tunnel_network and ipv6_nat_enabled:
+                post_up_cmds.append(
+                    f"ip6tables -t nat -A POSTROUTING -s {ipv6_tunnel_network} -o eth0 -j MASQUERADE"
+                )
+            post_up = "; ".join(post_up_cmds)
+
         if not post_down:
-            post_down = (
-                f"iptables -D FORWARD -i {self.interface_name} -j ACCEPT; "
-                f"iptables -D FORWARD -o {self.interface_name} -j ACCEPT; "
-                f"iptables -t nat -D POSTROUTING -s {network_cidr} -o eth0 -j MASQUERADE"
-            )
-        
+            post_down_cmds = [
+                f"iptables -D FORWARD -i {self.interface_name} -j ACCEPT",
+                f"iptables -D FORWARD -o {self.interface_name} -j ACCEPT",
+                f"iptables -t nat -D POSTROUTING -s {network_cidr} -o eth0 -j MASQUERADE",
+            ]
+            post_down_cmds.extend([
+                f"ip6tables -D FORWARD -i {self.interface_name} -j ACCEPT",
+                f"ip6tables -D FORWARD -o {self.interface_name} -j ACCEPT",
+            ])
+            if ipv6_tunnel_network and ipv6_nat_enabled:
+                post_down_cmds.append(
+                    f"ip6tables -t nat -D POSTROUTING -s {ipv6_tunnel_network} -o eth0 -j MASQUERADE"
+                )
+            post_down = "; ".join(post_down_cmds)
+
         config += f"PostUp = {post_up}\n"
         config += f"PostDown = {post_down}\n"
-        
+
         return config
     
     def add_peer(
@@ -243,9 +268,10 @@ class IPSecManager:
         server_id: str,
         left_subnet: str,
         right_source_ip: str = "10.201.0.0/24",
+        right_source_ip_v6: Optional[str] = None,
         eap_enabled: bool = True
     ) -> str:
-        """Create IKEv2 road warrior (remote access) config"""
+        """Create IKEv2 road warrior (remote access) config (dual-stack aware)"""
         config = f"""config setup
     charondebug="ike 2, knl 2, cfg 2, net 2, esp 2, dmn 2, mgr 2"
     uniqueids=yes
@@ -258,34 +284,36 @@ conn {server_id}
     keyexchange=ikev2
     fragmentation=yes
     forceencaps=yes
-    
+
     # Left (local) side
     left=%any
     leftid=@{server_id}
     leftcert=serverCert.pem
     leftsendcert=always
     leftsubnet={left_subnet}
-    
+
     # Right (remote) side
     right=%any
     rightid=%any
     rightauth=eap-mschapv2
     rightsourceip={right_source_ip}
     rightdns=1.1.1.1,1.0.0.1
-    
+
     # IKE (Phase 1) - Modern secure defaults
     ike=aes256gcm16-sha384-ecp384!
     esp=aes256gcm16-sha384-ecp384!
-    
+
     # DPD
     dpdaction=clear
     dpddelay=300s
     dpdtimeout=1500s
-    
+
     # Lifetime
     ikelifetime=24h
     lifetime=8h
 """
+        if right_source_ip_v6:
+            config += f"    rightsourceip={right_source_ip_v6}\n"
         return config
     
     def create_site_to_site_config(
@@ -358,11 +386,12 @@ class OpenVPNManager:
         protocol: str = "udp",
         network: str = "10.202.0.0",
         netmask: str = "255.255.255.0",
+        ipv6_tunnel_network: Optional[str] = None,
         cipher: str = "AES-256-GCM",
         auth_digest: str = "SHA256",
         tls_version: str = "1.2"
     ) -> str:
-        """Create OpenVPN server configuration"""
+        """Create OpenVPN server configuration (dual-stack aware)"""
         config = f"""# OpenVPN Server Configuration
 port {port}
 proto {protocol}
@@ -371,7 +400,11 @@ dev tun
 # Network
 server {network} {netmask}
 ifconfig-pool-persist /var/log/openvpn/ipp.txt
+"""
+        if ipv6_tunnel_network:
+            config += f"server-ipv6 {ipv6_tunnel_network}\n"
 
+        config += """
 push "redirect-gateway def1 bypass-dhcp"
 push "dhcp-option DNS 1.1.1.1"
 push "dhcp-option DNS 1.0.0.1"
@@ -493,21 +526,25 @@ class VPNAgent:
         private_key = config.get("private_key")
         if not private_key:
             private_key, public_key = await self.wireguard.generate_keypair()
-        
+
+        wg_cfg = config.get("wireguard_config", {})
+
         # Create server config
         wg_config = self.wireguard.create_server_config(
             private_key=private_key,
             listen_port=config.get("listen_port", 51820),
             network_cidr=config.get("network_cidr", "10.200.0.0/24"),
+            ipv6_tunnel_network=config.get("ipv6_tunnel_network"),
+            ipv6_nat_enabled=wg_cfg.get("ipv6_nat_enabled", False),
             post_up=config.get("post_up"),
             post_down=config.get("post_down")
         )
-        
+
         # Add existing peers
         for peer in config.get("peers", []):
             client = VPNClientConfig(**peer)
             wg_config = self.wireguard.add_peer(wg_config, client)
-        
+
         return await self.wireguard.apply_config(wg_config)
     
     async def _deploy_ipsec(self, config: Dict[str, Any]) -> bool:
@@ -517,11 +554,12 @@ class VPNAgent:
             ipsec_config = self.ipsec.create_road_warrior_config(
                 server_id=config.get("name", "viswall"),
                 left_subnet=config.get("left_subnet", "0.0.0.0/0"),
-                right_source_ip=config.get("network_cidr", "10.201.0.0/24")
+                right_source_ip=config.get("network_cidr", "10.201.0.0/24"),
+                right_source_ip_v6=config.get("ipv6_tunnel_network")
             )
         else:
             ipsec_config = self.ipsec.create_site_to_site_config(**config)
-        
+
         secrets = config.get("secrets", "")
         return await self.ipsec.apply_config(ipsec_config, secrets)
     
@@ -531,6 +569,7 @@ class VPNAgent:
             port=config.get("port", 1194),
             protocol=config.get("protocol", "udp"),
             network=config.get("network", "10.202.0.0"),
+            ipv6_tunnel_network=config.get("ipv6_tunnel_network"),
             cipher=config.get("cipher", "AES-256-GCM")
         )
         

--- a/shared/models.py
+++ b/shared/models.py
@@ -315,6 +315,7 @@ class VPNServer(Base):
     listen_address = Column(String(45), default="0.0.0.0")
     listen_port = Column(Integer)
     network_cidr = Column(String(50))  # VPN subnet (e.g., 10.200.0.0/24)
+    ipv6_tunnel_network = Column(String(50))  # IPv6 VPN subnet (e.g., fd00:200::/64)
 
     # DNS and routing
     dns_servers = Column(JSON, default=list)

--- a/shared/schemas.py
+++ b/shared/schemas.py
@@ -1,4 +1,4 @@
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, IPvAnyNetwork
 from typing import Optional, List, Dict, Any
 from datetime import datetime
 from enum import Enum
@@ -951,9 +951,7 @@ class VPNConnectionResponse(BaseModel):
 
 # VPN Routing
 class VPNRouteBase(BaseModel):
-    destination: str = Field(
-        ..., pattern=r"^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}/\d{1,2}$"
-    )
+    destination: IPvAnyNetwork
     gateway: Optional[str] = None
     metric: int = 0
     apply_to_all: bool = True

--- a/shared/schemas.py
+++ b/shared/schemas.py
@@ -699,6 +699,8 @@ class WireGuardConfig(BaseModel):
     public_key: Optional[str] = None
     listen_port: int = Field(default=51820, ge=1, le=65535)
     network_cidr: str = "10.200.0.0/24"
+    ipv6_tunnel_network: Optional[str] = None
+    ipv6_nat_enabled: bool = False
     post_up: Optional[str] = None
     post_down: Optional[str] = None
 
@@ -809,6 +811,7 @@ class VPNServerBase(BaseModel):
     listen_address: str = "0.0.0.0"
     listen_port: Optional[int] = None
     network_cidr: str = "10.200.0.0/24"
+    ipv6_tunnel_network: Optional[str] = None
 
     # Client settings
     dns_servers: List[str] = Field(default_factory=lambda: ["1.1.1.1", "1.0.0.1"])

--- a/web-ui/src/components/forms/FirewallRuleForm.tsx
+++ b/web-ui/src/components/forms/FirewallRuleForm.tsx
@@ -92,7 +92,7 @@ export function FirewallRuleForm({ initial, onSubmit, onCancel, loading }: Firew
               type="text"
               value={sourceValue}
               onChange={(e) => setSourceValue(e.target.value)}
-              placeholder={sourceType === 'network' ? '10.0.0.0/8' : 'eth0'}
+              placeholder={sourceType === 'network' ? '10.0.0.0/8 or 2001:db8::/64' : 'eth0'}
               className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500"
             />
           </div>
@@ -120,7 +120,7 @@ export function FirewallRuleForm({ initial, onSubmit, onCancel, loading }: Firew
               type="text"
               value={destValue}
               onChange={(e) => setDestValue(e.target.value)}
-              placeholder={destType === 'network' ? '192.168.1.0/24' : 'eth1'}
+              placeholder={destType === 'network' ? '192.168.1.0/24 or fd00::/64' : 'eth1'}
               className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500"
             />
           </div>

--- a/web-ui/src/pages/RoutingRules.tsx
+++ b/web-ui/src/pages/RoutingRules.tsx
@@ -280,7 +280,7 @@ function RoutingRuleForm({ initial, onSubmit, onCancel, loading }: RoutingRuleFo
             value={form.source_network || ''}
             onChange={(e) => setForm({ ...form, source_network: e.target.value || undefined })}
             className={inputClass}
-            placeholder="10.0.0.0/24"
+            placeholder="10.0.0.0/24 or 2001:db8::/64"
           />
         </div>
         <div>
@@ -290,7 +290,7 @@ function RoutingRuleForm({ initial, onSubmit, onCancel, loading }: RoutingRuleFo
             value={form.dest_network || ''}
             onChange={(e) => setForm({ ...form, dest_network: e.target.value || undefined })}
             className={inputClass}
-            placeholder="0.0.0.0/0"
+            placeholder="0.0.0.0/0 or ::/0"
           />
         </div>
       </div>
@@ -326,7 +326,7 @@ function RoutingRuleForm({ initial, onSubmit, onCancel, loading }: RoutingRuleFo
             value={form.gateway || ''}
             onChange={(e) => setForm({ ...form, gateway: e.target.value || undefined })}
             className={inputClass}
-            placeholder="192.168.1.1"
+            placeholder="192.168.1.1 or 2001:db8::1"
           />
         </div>
         <div>

--- a/web-ui/src/types/index.ts
+++ b/web-ui/src/types/index.ts
@@ -304,6 +304,7 @@ export interface VPNServer {
   listen_address: string;
   listen_port: number | null;
   network_cidr: string;
+  ipv6_tunnel_network?: string;
   dns_servers: string[];
   push_routes: string[];
   internet_redirect: boolean;
@@ -325,6 +326,7 @@ export interface VPNServerCreate {
   listen_address?: string;
   listen_port?: number;
   network_cidr?: string;
+  ipv6_tunnel_network?: string;
   dns_servers?: string[];
   push_routes?: string[];
   internet_redirect?: boolean;
@@ -342,6 +344,7 @@ export interface VPNServerUpdate {
   listen_address?: string;
   listen_port?: number;
   network_cidr?: string;
+  ipv6_tunnel_network?: string;
   dns_servers?: string[];
   push_routes?: string[];
   internet_redirect?: boolean;
@@ -353,6 +356,8 @@ export interface WireGuardConfig {
   public_key?: string;
   listen_port?: number;
   network_cidr?: string;
+  ipv6_tunnel_network?: string;
+  ipv6_nat_enabled?: boolean;
   post_up?: string;
   post_down?: string;
   mtu?: number;


### PR DESCRIPTION
## Summary

Adds IPv6 tunneling support to all VPN protocols with routed IPv6 by default and an optional NAT toggle for WireGuard.

## Changes

- **Database** — Added `ipv6_tunnel_network` column to `vpn_servers` table (Alembic migration `6e439a8a2c2a`)
- **Schemas** — Added `ipv6_tunnel_network` to `VPNServerBase` and `WireGuardConfig`; added `ipv6_nat_enabled` to `WireGuardConfig`
- **WireGuard** — `create_server_config` now accepts `ipv6_tunnel_network` and `ipv6_nat_enabled`. Generates `ip6tables` FORWARD rules unconditionally; adds `ip6tables -t nat` only when `ipv6_nat_enabled=True`. Server `Address` field includes both IPv4 and IPv6 CIDRs when provided.
- **IPsec** — `create_road_warrior_config` supports an optional `right_source_ip_v6` parameter for IPv6 client pools.
- **OpenVPN** — `create_server_config` adds `server-ipv6` directive when `ipv6_tunnel_network` is provided.
- **Frontend types** — Updated `VPNServer*`, `WireGuardConfig` interfaces with new fields.

## Related

Part of the IPv6 support series: PR #1 → #2 → #3 → **#4** → #5 → #6