### PR TITLE
feat(dhcp): add backend module for DHCPv4 and DHCPv6 management

### DIFF
--- a/services/api-gateway/main.py
+++ b/services/api-gateway/main.py
@@ -6,7 +6,7 @@ import asyncio
 import os
 import time
 
-from routers import auth, instances, users, firewall, mail, metrics, routing, audit, vpn, firewall_simulation, assistant, groupware, llm_admin, dns
+from routers import auth, instances, users, firewall, mail, metrics, routing, audit, vpn, firewall_simulation, assistant, groupware, llm_admin, dns, dhcp
 from shared.database import init_db, get_db
 from shared.models import Base
 from metrics_collector import start_metrics_collector
@@ -113,6 +113,7 @@ app.include_router(metrics.router, prefix="/api/v1/metrics", tags=["Metrics"])
 app.include_router(audit.router, prefix="/api/v1/audit", tags=["Audit"])
 app.include_router(vpn.router, prefix="/api/v1/vpn", tags=["VPN"])
 app.include_router(dns.router, prefix="/api/v1/dns", tags=["DNS"])
+app.include_router(dhcp.router, prefix="/api/v1/dhcp", tags=["DHCP"])
 app.include_router(
     firewall_simulation.router,
     prefix="/api/v1/simulation",
@@ -152,5 +153,6 @@ async def api_info():
             "dns-zones-and-records",
             "dnssec",
             "forward-and-reverse-dns",
+            "dhcpv4-and-dhcpv6-server-management",
         ],
     }

--- a/services/api-gateway/migrations/versions/bd213a2f9c31_add_dhcp_module_tables.py
+++ b/services/api-gateway/migrations/versions/bd213a2f9c31_add_dhcp_module_tables.py
@@ -1,0 +1,140 @@
+"""add_dhcp_module_tables
+
+Revision ID: bd213a2f9c31
+Revises: 9f2c7a1d4b5e
+Create Date: 2026-04-26 16:20:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "bd213a2f9c31"
+down_revision: Union[str, None] = "9f2c7a1d4b5e"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "dhcp_servers",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("instance_id", sa.Integer(), nullable=False),
+        sa.Column("name", sa.String(length=100), nullable=False),
+        sa.Column("description", sa.Text(), nullable=True),
+        sa.Column("enabled", sa.Boolean(), nullable=True),
+        sa.Column("status", sa.String(length=20), nullable=True),
+        sa.Column("kea_ctrl_agent_address", sa.String(length=255), nullable=True),
+        sa.Column("kea_ctrl_agent_port", sa.Integer(), nullable=True),
+        sa.Column("ha_enabled", sa.Boolean(), nullable=True),
+        sa.Column("ha_mode", sa.String(length=20), nullable=True),
+        sa.Column("ha_peer_address", sa.String(length=255), nullable=True),
+        sa.Column("dhcpv4_enabled", sa.Boolean(), nullable=True),
+        sa.Column("dhcpv6_enabled", sa.Boolean(), nullable=True),
+        sa.Column("created_by", sa.Integer(), nullable=True),
+        sa.Column("created_at", sa.DateTime(), nullable=True),
+        sa.Column("updated_at", sa.DateTime(), nullable=True),
+        sa.ForeignKeyConstraint(["created_by"], ["users.id"]),
+        sa.ForeignKeyConstraint(["instance_id"], ["instances.id"]),
+        sa.PrimaryKeyConstraint("id"),
+    )
+
+    op.create_table(
+        "dhcp_subnets",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("server_id", sa.Integer(), nullable=False),
+        sa.Column("name", sa.String(length=100), nullable=False),
+        sa.Column("description", sa.Text(), nullable=True),
+        sa.Column("subnet", sa.String(length=100), nullable=False),
+        sa.Column("type", sa.String(length=10), nullable=False),
+        sa.Column("interface", sa.String(length=50), nullable=True),
+        sa.Column("relay_addresses", sa.JSON(), nullable=True),
+        sa.Column("domain_name", sa.String(length=255), nullable=True),
+        sa.Column("dns_servers", sa.JSON(), nullable=True),
+        sa.Column("ntp_servers", sa.JSON(), nullable=True),
+        sa.Column("routers", sa.JSON(), nullable=True),
+        sa.Column("lease_time_default", sa.Integer(), nullable=True),
+        sa.Column("lease_time_max", sa.Integer(), nullable=True),
+        sa.Column("lease_time_min", sa.Integer(), nullable=True),
+        sa.Column("delegated_prefix_length", sa.Integer(), nullable=True),
+        sa.Column("enabled", sa.Boolean(), nullable=True),
+        sa.Column("created_at", sa.DateTime(), nullable=True),
+        sa.Column("updated_at", sa.DateTime(), nullable=True),
+        sa.ForeignKeyConstraint(["server_id"], ["dhcp_servers.id"]),
+        sa.PrimaryKeyConstraint("id"),
+    )
+
+    op.create_table(
+        "dhcp_pools",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("subnet_id", sa.Integer(), nullable=False),
+        sa.Column("start_address", sa.String(length=45), nullable=False),
+        sa.Column("end_address", sa.String(length=45), nullable=False),
+        sa.Column("type", sa.String(length=10), nullable=False),
+        sa.Column("enabled", sa.Boolean(), nullable=True),
+        sa.Column("created_at", sa.DateTime(), nullable=True),
+        sa.Column("updated_at", sa.DateTime(), nullable=True),
+        sa.ForeignKeyConstraint(["subnet_id"], ["dhcp_subnets.id"]),
+        sa.PrimaryKeyConstraint("id"),
+    )
+
+    op.create_table(
+        "dhcp_reservations",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("subnet_id", sa.Integer(), nullable=False),
+        sa.Column("hostname", sa.String(length=255), nullable=True),
+        sa.Column("ip_address", sa.String(length=45), nullable=False),
+        sa.Column("hw_address", sa.String(length=255), nullable=False),
+        sa.Column("type", sa.String(length=10), nullable=False),
+        sa.Column("description", sa.Text(), nullable=True),
+        sa.Column("created_at", sa.DateTime(), nullable=True),
+        sa.Column("updated_at", sa.DateTime(), nullable=True),
+        sa.ForeignKeyConstraint(["subnet_id"], ["dhcp_subnets.id"]),
+        sa.PrimaryKeyConstraint("id"),
+    )
+
+    op.create_table(
+        "dhcp_options",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("subnet_id", sa.Integer(), nullable=False),
+        sa.Column("option_code", sa.Integer(), nullable=False),
+        sa.Column("option_name", sa.String(length=100), nullable=False),
+        sa.Column("option_value", sa.Text(), nullable=False),
+        sa.Column("type", sa.String(length=10), nullable=False),
+        sa.Column("created_at", sa.DateTime(), nullable=True),
+        sa.Column("updated_at", sa.DateTime(), nullable=True),
+        sa.ForeignKeyConstraint(["subnet_id"], ["dhcp_subnets.id"]),
+        sa.PrimaryKeyConstraint("id"),
+    )
+
+    op.create_table(
+        "dhcp_leases",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("subnet_id", sa.Integer(), nullable=False),
+        sa.Column("pool_id", sa.Integer(), nullable=True),
+        sa.Column("ip_address", sa.String(length=45), nullable=False),
+        sa.Column("hw_address", sa.String(length=255), nullable=True),
+        sa.Column("hostname", sa.String(length=255), nullable=True),
+        sa.Column("client_id", sa.String(length=255), nullable=True),
+        sa.Column("lease_start", sa.DateTime(), nullable=True),
+        sa.Column("lease_end", sa.DateTime(), nullable=True),
+        sa.Column("released_at", sa.DateTime(), nullable=True),
+        sa.Column("state", sa.String(length=20), nullable=True),
+        sa.Column("created_at", sa.DateTime(), nullable=True),
+        sa.Column("updated_at", sa.DateTime(), nullable=True),
+        sa.ForeignKeyConstraint(["pool_id"], ["dhcp_pools.id"]),
+        sa.ForeignKeyConstraint(["subnet_id"], ["dhcp_subnets.id"]),
+        sa.PrimaryKeyConstraint("id"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("dhcp_leases")
+    op.drop_table("dhcp_options")
+    op.drop_table("dhcp_reservations")
+    op.drop_table("dhcp_pools")
+    op.drop_table("dhcp_subnets")
+    op.drop_table("dhcp_servers")

--- a/services/api-gateway/routers/dhcp.py
+++ b/services/api-gateway/routers/dhcp.py
@@ -1,0 +1,886 @@
+from datetime import datetime
+from typing import List
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from shared.audit_logger import log_audit
+from shared.database import get_db
+from shared.models import (
+    DHCPLease,
+    DHCPOption,
+    DHCPPool,
+    DHCPReservation,
+    DHCPServer,
+    DHCPSubnet,
+    Instance,
+)
+from shared.schemas import (
+    DHCPLeaseReleaseResponse,
+    DHCPLeaseResponse,
+    DHCPOptionCreate,
+    DHCPOptionResponse,
+    DHCPOptionUpdate,
+    DHCPPoolCreate,
+    DHCPPoolResponse,
+    DHCPPoolUpdate,
+    DHCPReservationCreate,
+    DHCPReservationResponse,
+    DHCPReservationUpdate,
+    DHCPServerCreate,
+    DHCPServerResponse,
+    DHCPServerUpdate,
+    DHCPSubnetCreate,
+    DHCPSubnetResponse,
+    DHCPSubnetType,
+    DHCPSubnetUpdate,
+)
+from shared.security import require_admin, require_auth
+
+router = APIRouter()
+
+
+def _validate_lease_windows(
+    lease_time_min: int, lease_time_default: int, lease_time_max: int
+) -> None:
+    if lease_time_min > lease_time_default or lease_time_default > lease_time_max:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="lease_time_min must be <= lease_time_default <= lease_time_max",
+        )
+
+
+def _validate_server_families(dhcpv4_enabled: bool, dhcpv6_enabled: bool) -> None:
+    if not dhcpv4_enabled and not dhcpv6_enabled:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="At least one of dhcpv4_enabled or dhcpv6_enabled must be true",
+        )
+
+
+def _validate_ha_settings(ha_enabled: bool, ha_peer_address: str | None) -> None:
+    if ha_enabled and not ha_peer_address:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="ha_peer_address is required when HA is enabled",
+        )
+
+
+def _assert_subnet_type_allowed(server: DHCPServer, subnet_type: str) -> None:
+    if subnet_type == DHCPSubnetType.V4.value and not server.dhcpv4_enabled:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="DHCPv4 is disabled on this server",
+        )
+    if subnet_type == DHCPSubnetType.V6.value and not server.dhcpv6_enabled:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="DHCPv6 is disabled on this server",
+        )
+
+
+@router.get("/servers/{instance_id}", response_model=List[DHCPServerResponse])
+async def list_servers(
+    instance_id: int,
+    user_id: int = Depends(require_auth),
+    db: AsyncSession = Depends(get_db),
+):
+    _ = user_id
+    result = await db.execute(
+        select(DHCPServer).where(DHCPServer.instance_id == instance_id).order_by(DHCPServer.id)
+    )
+    servers = result.scalars().all()
+
+    responses: List[DHCPServerResponse] = []
+    for server in servers:
+        count_result = await db.execute(
+            select(func.count(DHCPSubnet.id)).where(DHCPSubnet.server_id == server.id)
+        )
+        item = DHCPServerResponse.model_validate(server)
+        item.subnets_count = int(count_result.scalar() or 0)
+        responses.append(item)
+    return responses
+
+
+@router.post(
+    "/servers/{instance_id}",
+    response_model=DHCPServerResponse,
+    status_code=status.HTTP_201_CREATED,
+)
+async def create_server(
+    instance_id: int,
+    data: DHCPServerCreate,
+    user_id: int = Depends(require_admin),
+    db: AsyncSession = Depends(get_db),
+):
+    instance_result = await db.execute(select(Instance).where(Instance.id == instance_id))
+    if not instance_result.scalar_one_or_none():
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Instance not found")
+
+    _validate_server_families(data.dhcpv4_enabled, data.dhcpv6_enabled)
+    _validate_ha_settings(data.ha_enabled, data.ha_peer_address)
+
+    server = DHCPServer(
+        instance_id=instance_id,
+        name=data.name,
+        description=data.description,
+        enabled=data.enabled,
+        status="stopped",
+        kea_ctrl_agent_address=data.kea_ctrl_agent_address,
+        kea_ctrl_agent_port=data.kea_ctrl_agent_port,
+        ha_enabled=data.ha_enabled,
+        ha_mode=data.ha_mode.value,
+        ha_peer_address=data.ha_peer_address,
+        dhcpv4_enabled=data.dhcpv4_enabled,
+        dhcpv6_enabled=data.dhcpv6_enabled,
+        created_by=user_id,
+    )
+    db.add(server)
+    await db.commit()
+    await log_audit(
+        db=db,
+        user_id=user_id,
+        action="create",
+        resource_type="dhcp_server",
+        resource_id=server.id,
+        instance_id=instance_id,
+    )
+    await db.refresh(server)
+    return DHCPServerResponse.model_validate(server)
+
+
+@router.get("/servers/detail/{server_id}", response_model=DHCPServerResponse)
+async def get_server(
+    server_id: int,
+    user_id: int = Depends(require_auth),
+    db: AsyncSession = Depends(get_db),
+):
+    _ = user_id
+    result = await db.execute(select(DHCPServer).where(DHCPServer.id == server_id))
+    server = result.scalar_one_or_none()
+    if not server:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="DHCP server not found")
+    count_result = await db.execute(
+        select(func.count(DHCPSubnet.id)).where(DHCPSubnet.server_id == server.id)
+    )
+    response = DHCPServerResponse.model_validate(server)
+    response.subnets_count = int(count_result.scalar() or 0)
+    return response
+
+
+@router.patch("/servers/{server_id}", response_model=DHCPServerResponse)
+async def update_server(
+    server_id: int,
+    data: DHCPServerUpdate,
+    user_id: int = Depends(require_admin),
+    db: AsyncSession = Depends(get_db),
+):
+    result = await db.execute(select(DHCPServer).where(DHCPServer.id == server_id))
+    server = result.scalar_one_or_none()
+    if not server:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="DHCP server not found")
+
+    update_data = data.model_dump(exclude_unset=True)
+
+    dhcpv4_enabled = update_data.get("dhcpv4_enabled", server.dhcpv4_enabled)
+    dhcpv6_enabled = update_data.get("dhcpv6_enabled", server.dhcpv6_enabled)
+    _validate_server_families(dhcpv4_enabled, dhcpv6_enabled)
+
+    ha_enabled = update_data.get("ha_enabled", server.ha_enabled)
+    ha_peer_address = update_data.get("ha_peer_address", server.ha_peer_address)
+    _validate_ha_settings(ha_enabled, ha_peer_address)
+
+    if (
+        (not dhcpv4_enabled and server.dhcpv4_enabled)
+        or (not dhcpv6_enabled and server.dhcpv6_enabled)
+    ):
+        subnets_result = await db.execute(
+            select(DHCPSubnet.id, DHCPSubnet.type).where(DHCPSubnet.server_id == server.id)
+        )
+        for _, subnet_type in subnets_result.all():
+            if subnet_type == DHCPSubnetType.V4.value and not dhcpv4_enabled:
+                raise HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    detail="Cannot disable DHCPv4 while v4 subnets exist",
+                )
+            if subnet_type == DHCPSubnetType.V6.value and not dhcpv6_enabled:
+                raise HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    detail="Cannot disable DHCPv6 while v6 subnets exist",
+                )
+
+    for field, value in update_data.items():
+        if field == "ha_mode" and value is not None:
+            setattr(server, field, value.value)
+        else:
+            setattr(server, field, value)
+
+    await db.commit()
+    await log_audit(
+        db=db,
+        user_id=user_id,
+        action="update",
+        resource_type="dhcp_server",
+        resource_id=server.id,
+        instance_id=server.instance_id,
+    )
+    await db.refresh(server)
+    return DHCPServerResponse.model_validate(server)
+
+
+@router.delete("/servers/{server_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_server(
+    server_id: int,
+    user_id: int = Depends(require_admin),
+    db: AsyncSession = Depends(get_db),
+):
+    result = await db.execute(select(DHCPServer).where(DHCPServer.id == server_id))
+    server = result.scalar_one_or_none()
+    if not server:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="DHCP server not found")
+    instance_id = server.instance_id
+    await db.delete(server)
+    await db.commit()
+    await log_audit(
+        db=db,
+        user_id=user_id,
+        action="delete",
+        resource_type="dhcp_server",
+        resource_id=server_id,
+        instance_id=instance_id,
+    )
+
+
+@router.post("/servers/{server_id}/actions/{action}")
+async def server_action(
+    server_id: int,
+    action: str,
+    user_id: int = Depends(require_admin),
+    db: AsyncSession = Depends(get_db),
+):
+    result = await db.execute(select(DHCPServer).where(DHCPServer.id == server_id))
+    server = result.scalar_one_or_none()
+    if not server:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="DHCP server not found")
+
+    allowed = {"start", "stop", "reload"}
+    if action not in allowed:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid action")
+
+    if action == "start":
+        server.status = "running"
+    elif action == "stop":
+        server.status = "stopped"
+
+    await db.commit()
+    await log_audit(
+        db=db,
+        user_id=user_id,
+        action="deploy",
+        resource_type="dhcp_server",
+        resource_id=server.id,
+        instance_id=server.instance_id,
+        new_value={"operation": action},
+    )
+    return {"status": "success", "action": action, "server_id": server_id}
+
+
+@router.get("/servers/{server_id}/subnets", response_model=List[DHCPSubnetResponse])
+async def list_subnets(
+    server_id: int,
+    user_id: int = Depends(require_auth),
+    db: AsyncSession = Depends(get_db),
+):
+    _ = user_id
+    result = await db.execute(
+        select(DHCPSubnet).where(DHCPSubnet.server_id == server_id).order_by(DHCPSubnet.id)
+    )
+    subnets = result.scalars().all()
+
+    responses: List[DHCPSubnetResponse] = []
+    for subnet in subnets:
+        pools_count = await db.execute(
+            select(func.count(DHCPPool.id)).where(DHCPPool.subnet_id == subnet.id)
+        )
+        reservations_count = await db.execute(
+            select(func.count(DHCPReservation.id)).where(DHCPReservation.subnet_id == subnet.id)
+        )
+        leases_count = await db.execute(
+            select(func.count(DHCPLease.id)).where(DHCPLease.subnet_id == subnet.id)
+        )
+        item = DHCPSubnetResponse.model_validate(subnet)
+        item.pools_count = int(pools_count.scalar() or 0)
+        item.reservations_count = int(reservations_count.scalar() or 0)
+        item.leases_count = int(leases_count.scalar() or 0)
+        responses.append(item)
+    return responses
+
+
+@router.post(
+    "/servers/{server_id}/subnets",
+    response_model=DHCPSubnetResponse,
+    status_code=status.HTTP_201_CREATED,
+)
+async def create_subnet(
+    server_id: int,
+    data: DHCPSubnetCreate,
+    user_id: int = Depends(require_admin),
+    db: AsyncSession = Depends(get_db),
+):
+    server_result = await db.execute(select(DHCPServer).where(DHCPServer.id == server_id))
+    server = server_result.scalar_one_or_none()
+    if not server:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="DHCP server not found")
+
+    _assert_subnet_type_allowed(server, data.type.value)
+    _validate_lease_windows(data.lease_time_min, data.lease_time_default, data.lease_time_max)
+
+    subnet = DHCPSubnet(
+        server_id=server_id,
+        name=data.name,
+        description=data.description,
+        subnet=data.subnet,
+        type=data.type.value,
+        interface=data.interface,
+        relay_addresses=data.relay_addresses,
+        domain_name=data.domain_name,
+        dns_servers=data.dns_servers,
+        ntp_servers=data.ntp_servers,
+        routers=data.routers,
+        lease_time_default=data.lease_time_default,
+        lease_time_max=data.lease_time_max,
+        lease_time_min=data.lease_time_min,
+        delegated_prefix_length=data.delegated_prefix_length,
+        enabled=data.enabled,
+    )
+    db.add(subnet)
+    await db.commit()
+    await log_audit(
+        db=db,
+        user_id=user_id,
+        action="create",
+        resource_type="dhcp_subnet",
+        resource_id=subnet.id,
+        instance_id=server.instance_id,
+    )
+    await db.refresh(subnet)
+    return DHCPSubnetResponse.model_validate(subnet)
+
+
+@router.get("/subnets/detail/{subnet_id}", response_model=DHCPSubnetResponse)
+async def get_subnet(
+    subnet_id: int,
+    user_id: int = Depends(require_auth),
+    db: AsyncSession = Depends(get_db),
+):
+    _ = user_id
+    result = await db.execute(select(DHCPSubnet).where(DHCPSubnet.id == subnet_id))
+    subnet = result.scalar_one_or_none()
+    if not subnet:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="DHCP subnet not found")
+
+    pools_count = await db.execute(select(func.count(DHCPPool.id)).where(DHCPPool.subnet_id == subnet.id))
+    reservations_count = await db.execute(
+        select(func.count(DHCPReservation.id)).where(DHCPReservation.subnet_id == subnet.id)
+    )
+    leases_count = await db.execute(
+        select(func.count(DHCPLease.id)).where(DHCPLease.subnet_id == subnet.id)
+    )
+    response = DHCPSubnetResponse.model_validate(subnet)
+    response.pools_count = int(pools_count.scalar() or 0)
+    response.reservations_count = int(reservations_count.scalar() or 0)
+    response.leases_count = int(leases_count.scalar() or 0)
+    return response
+
+
+@router.patch("/subnets/{subnet_id}", response_model=DHCPSubnetResponse)
+async def update_subnet(
+    subnet_id: int,
+    data: DHCPSubnetUpdate,
+    user_id: int = Depends(require_admin),
+    db: AsyncSession = Depends(get_db),
+):
+    result = await db.execute(select(DHCPSubnet).where(DHCPSubnet.id == subnet_id))
+    subnet = result.scalar_one_or_none()
+    if not subnet:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="DHCP subnet not found")
+
+    update_data = data.model_dump(exclude_unset=True)
+
+    lease_time_min = update_data.get("lease_time_min", subnet.lease_time_min)
+    lease_time_default = update_data.get("lease_time_default", subnet.lease_time_default)
+    lease_time_max = update_data.get("lease_time_max", subnet.lease_time_max)
+    _validate_lease_windows(lease_time_min, lease_time_default, lease_time_max)
+
+    for field, value in update_data.items():
+        setattr(subnet, field, value)
+
+    await db.commit()
+    server_result = await db.execute(select(DHCPServer).where(DHCPServer.id == subnet.server_id))
+    server = server_result.scalar_one()
+    await log_audit(
+        db=db,
+        user_id=user_id,
+        action="update",
+        resource_type="dhcp_subnet",
+        resource_id=subnet.id,
+        instance_id=server.instance_id,
+    )
+    await db.refresh(subnet)
+    return DHCPSubnetResponse.model_validate(subnet)
+
+
+@router.delete("/subnets/{subnet_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_subnet(
+    subnet_id: int,
+    user_id: int = Depends(require_admin),
+    db: AsyncSession = Depends(get_db),
+):
+    result = await db.execute(select(DHCPSubnet).where(DHCPSubnet.id == subnet_id))
+    subnet = result.scalar_one_or_none()
+    if not subnet:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="DHCP subnet not found")
+    server_result = await db.execute(select(DHCPServer).where(DHCPServer.id == subnet.server_id))
+    server = server_result.scalar_one()
+    await db.delete(subnet)
+    await db.commit()
+    await log_audit(
+        db=db,
+        user_id=user_id,
+        action="delete",
+        resource_type="dhcp_subnet",
+        resource_id=subnet_id,
+        instance_id=server.instance_id,
+    )
+
+
+@router.get("/subnets/{subnet_id}/pools", response_model=List[DHCPPoolResponse])
+async def list_pools(
+    subnet_id: int,
+    user_id: int = Depends(require_auth),
+    db: AsyncSession = Depends(get_db),
+):
+    _ = user_id
+    result = await db.execute(
+        select(DHCPPool).where(DHCPPool.subnet_id == subnet_id).order_by(DHCPPool.id)
+    )
+    return [DHCPPoolResponse.model_validate(item) for item in result.scalars().all()]
+
+
+@router.post(
+    "/subnets/{subnet_id}/pools",
+    response_model=DHCPPoolResponse,
+    status_code=status.HTTP_201_CREATED,
+)
+async def create_pool(
+    subnet_id: int,
+    data: DHCPPoolCreate,
+    user_id: int = Depends(require_admin),
+    db: AsyncSession = Depends(get_db),
+):
+    subnet_result = await db.execute(select(DHCPSubnet).where(DHCPSubnet.id == subnet_id))
+    subnet = subnet_result.scalar_one_or_none()
+    if not subnet:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="DHCP subnet not found")
+    if data.type.value != subnet.type:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Pool type must match subnet type",
+        )
+
+    pool = DHCPPool(
+        subnet_id=subnet_id,
+        start_address=data.start_address,
+        end_address=data.end_address,
+        type=data.type.value,
+        enabled=data.enabled,
+    )
+    db.add(pool)
+    await db.commit()
+    server_result = await db.execute(select(DHCPServer).where(DHCPServer.id == subnet.server_id))
+    server = server_result.scalar_one()
+    await log_audit(
+        db=db,
+        user_id=user_id,
+        action="create",
+        resource_type="dhcp_pool",
+        resource_id=pool.id,
+        instance_id=server.instance_id,
+    )
+    await db.refresh(pool)
+    return DHCPPoolResponse.model_validate(pool)
+
+
+@router.patch("/pools/{pool_id}", response_model=DHCPPoolResponse)
+async def update_pool(
+    pool_id: int,
+    data: DHCPPoolUpdate,
+    user_id: int = Depends(require_admin),
+    db: AsyncSession = Depends(get_db),
+):
+    result = await db.execute(select(DHCPPool).where(DHCPPool.id == pool_id))
+    pool = result.scalar_one_or_none()
+    if not pool:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="DHCP pool not found")
+
+    for field, value in data.model_dump(exclude_unset=True).items():
+        setattr(pool, field, value)
+
+    await db.commit()
+    subnet_result = await db.execute(select(DHCPSubnet).where(DHCPSubnet.id == pool.subnet_id))
+    subnet = subnet_result.scalar_one()
+    server_result = await db.execute(select(DHCPServer).where(DHCPServer.id == subnet.server_id))
+    server = server_result.scalar_one()
+    await log_audit(
+        db=db,
+        user_id=user_id,
+        action="update",
+        resource_type="dhcp_pool",
+        resource_id=pool.id,
+        instance_id=server.instance_id,
+    )
+    await db.refresh(pool)
+    return DHCPPoolResponse.model_validate(pool)
+
+
+@router.delete("/pools/{pool_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_pool(
+    pool_id: int,
+    user_id: int = Depends(require_admin),
+    db: AsyncSession = Depends(get_db),
+):
+    result = await db.execute(select(DHCPPool).where(DHCPPool.id == pool_id))
+    pool = result.scalar_one_or_none()
+    if not pool:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="DHCP pool not found")
+
+    subnet_result = await db.execute(select(DHCPSubnet).where(DHCPSubnet.id == pool.subnet_id))
+    subnet = subnet_result.scalar_one()
+    server_result = await db.execute(select(DHCPServer).where(DHCPServer.id == subnet.server_id))
+    server = server_result.scalar_one()
+
+    await db.delete(pool)
+    await db.commit()
+    await log_audit(
+        db=db,
+        user_id=user_id,
+        action="delete",
+        resource_type="dhcp_pool",
+        resource_id=pool_id,
+        instance_id=server.instance_id,
+    )
+
+
+@router.get("/subnets/{subnet_id}/reservations", response_model=List[DHCPReservationResponse])
+async def list_reservations(
+    subnet_id: int,
+    user_id: int = Depends(require_auth),
+    db: AsyncSession = Depends(get_db),
+):
+    _ = user_id
+    result = await db.execute(
+        select(DHCPReservation)
+        .where(DHCPReservation.subnet_id == subnet_id)
+        .order_by(DHCPReservation.id)
+    )
+    return [DHCPReservationResponse.model_validate(item) for item in result.scalars().all()]
+
+
+@router.post(
+    "/subnets/{subnet_id}/reservations",
+    response_model=DHCPReservationResponse,
+    status_code=status.HTTP_201_CREATED,
+)
+async def create_reservation(
+    subnet_id: int,
+    data: DHCPReservationCreate,
+    user_id: int = Depends(require_admin),
+    db: AsyncSession = Depends(get_db),
+):
+    subnet_result = await db.execute(select(DHCPSubnet).where(DHCPSubnet.id == subnet_id))
+    subnet = subnet_result.scalar_one_or_none()
+    if not subnet:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="DHCP subnet not found")
+    if data.type.value != subnet.type:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Reservation type must match subnet type",
+        )
+
+    reservation = DHCPReservation(
+        subnet_id=subnet_id,
+        hostname=data.hostname,
+        ip_address=data.ip_address,
+        hw_address=data.hw_address,
+        type=data.type.value,
+        description=data.description,
+    )
+    db.add(reservation)
+    await db.commit()
+    server_result = await db.execute(select(DHCPServer).where(DHCPServer.id == subnet.server_id))
+    server = server_result.scalar_one()
+    await log_audit(
+        db=db,
+        user_id=user_id,
+        action="create",
+        resource_type="dhcp_reservation",
+        resource_id=reservation.id,
+        instance_id=server.instance_id,
+    )
+    await db.refresh(reservation)
+    return DHCPReservationResponse.model_validate(reservation)
+
+
+@router.patch("/reservations/{reservation_id}", response_model=DHCPReservationResponse)
+async def update_reservation(
+    reservation_id: int,
+    data: DHCPReservationUpdate,
+    user_id: int = Depends(require_admin),
+    db: AsyncSession = Depends(get_db),
+):
+    result = await db.execute(
+        select(DHCPReservation).where(DHCPReservation.id == reservation_id)
+    )
+    reservation = result.scalar_one_or_none()
+    if not reservation:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="DHCP reservation not found",
+        )
+
+    for field, value in data.model_dump(exclude_unset=True).items():
+        setattr(reservation, field, value)
+
+    await db.commit()
+    subnet_result = await db.execute(
+        select(DHCPSubnet).where(DHCPSubnet.id == reservation.subnet_id)
+    )
+    subnet = subnet_result.scalar_one()
+    server_result = await db.execute(select(DHCPServer).where(DHCPServer.id == subnet.server_id))
+    server = server_result.scalar_one()
+    await log_audit(
+        db=db,
+        user_id=user_id,
+        action="update",
+        resource_type="dhcp_reservation",
+        resource_id=reservation.id,
+        instance_id=server.instance_id,
+    )
+    await db.refresh(reservation)
+    return DHCPReservationResponse.model_validate(reservation)
+
+
+@router.delete("/reservations/{reservation_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_reservation(
+    reservation_id: int,
+    user_id: int = Depends(require_admin),
+    db: AsyncSession = Depends(get_db),
+):
+    result = await db.execute(
+        select(DHCPReservation).where(DHCPReservation.id == reservation_id)
+    )
+    reservation = result.scalar_one_or_none()
+    if not reservation:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="DHCP reservation not found",
+        )
+
+    subnet_result = await db.execute(
+        select(DHCPSubnet).where(DHCPSubnet.id == reservation.subnet_id)
+    )
+    subnet = subnet_result.scalar_one()
+    server_result = await db.execute(select(DHCPServer).where(DHCPServer.id == subnet.server_id))
+    server = server_result.scalar_one()
+
+    await db.delete(reservation)
+    await db.commit()
+    await log_audit(
+        db=db,
+        user_id=user_id,
+        action="delete",
+        resource_type="dhcp_reservation",
+        resource_id=reservation_id,
+        instance_id=server.instance_id,
+    )
+
+
+@router.get("/subnets/{subnet_id}/options", response_model=List[DHCPOptionResponse])
+async def list_options(
+    subnet_id: int,
+    user_id: int = Depends(require_auth),
+    db: AsyncSession = Depends(get_db),
+):
+    _ = user_id
+    result = await db.execute(
+        select(DHCPOption).where(DHCPOption.subnet_id == subnet_id).order_by(DHCPOption.id)
+    )
+    return [DHCPOptionResponse.model_validate(item) for item in result.scalars().all()]
+
+
+@router.post(
+    "/subnets/{subnet_id}/options",
+    response_model=DHCPOptionResponse,
+    status_code=status.HTTP_201_CREATED,
+)
+async def create_option(
+    subnet_id: int,
+    data: DHCPOptionCreate,
+    user_id: int = Depends(require_admin),
+    db: AsyncSession = Depends(get_db),
+):
+    subnet_result = await db.execute(select(DHCPSubnet).where(DHCPSubnet.id == subnet_id))
+    subnet = subnet_result.scalar_one_or_none()
+    if not subnet:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="DHCP subnet not found")
+    if data.type.value != subnet.type:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Option type must match subnet type",
+        )
+
+    option = DHCPOption(
+        subnet_id=subnet_id,
+        option_code=data.option_code,
+        option_name=data.option_name,
+        option_value=data.option_value,
+        type=data.type.value,
+    )
+    db.add(option)
+    await db.commit()
+    server_result = await db.execute(select(DHCPServer).where(DHCPServer.id == subnet.server_id))
+    server = server_result.scalar_one()
+    await log_audit(
+        db=db,
+        user_id=user_id,
+        action="create",
+        resource_type="dhcp_option",
+        resource_id=option.id,
+        instance_id=server.instance_id,
+    )
+    await db.refresh(option)
+    return DHCPOptionResponse.model_validate(option)
+
+
+@router.patch("/options/{option_id}", response_model=DHCPOptionResponse)
+async def update_option(
+    option_id: int,
+    data: DHCPOptionUpdate,
+    user_id: int = Depends(require_admin),
+    db: AsyncSession = Depends(get_db),
+):
+    result = await db.execute(select(DHCPOption).where(DHCPOption.id == option_id))
+    option = result.scalar_one_or_none()
+    if not option:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="DHCP option not found")
+
+    for field, value in data.model_dump(exclude_unset=True).items():
+        setattr(option, field, value)
+
+    await db.commit()
+    subnet_result = await db.execute(select(DHCPSubnet).where(DHCPSubnet.id == option.subnet_id))
+    subnet = subnet_result.scalar_one()
+    server_result = await db.execute(select(DHCPServer).where(DHCPServer.id == subnet.server_id))
+    server = server_result.scalar_one()
+    await log_audit(
+        db=db,
+        user_id=user_id,
+        action="update",
+        resource_type="dhcp_option",
+        resource_id=option.id,
+        instance_id=server.instance_id,
+    )
+    await db.refresh(option)
+    return DHCPOptionResponse.model_validate(option)
+
+
+@router.delete("/options/{option_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_option(
+    option_id: int,
+    user_id: int = Depends(require_admin),
+    db: AsyncSession = Depends(get_db),
+):
+    result = await db.execute(select(DHCPOption).where(DHCPOption.id == option_id))
+    option = result.scalar_one_or_none()
+    if not option:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="DHCP option not found")
+
+    subnet_result = await db.execute(select(DHCPSubnet).where(DHCPSubnet.id == option.subnet_id))
+    subnet = subnet_result.scalar_one()
+    server_result = await db.execute(select(DHCPServer).where(DHCPServer.id == subnet.server_id))
+    server = server_result.scalar_one()
+
+    await db.delete(option)
+    await db.commit()
+    await log_audit(
+        db=db,
+        user_id=user_id,
+        action="delete",
+        resource_type="dhcp_option",
+        resource_id=option_id,
+        instance_id=server.instance_id,
+    )
+
+
+@router.get("/subnets/{subnet_id}/leases", response_model=List[DHCPLeaseResponse])
+async def list_subnet_leases(
+    subnet_id: int,
+    user_id: int = Depends(require_auth),
+    db: AsyncSession = Depends(get_db),
+):
+    _ = user_id
+    result = await db.execute(
+        select(DHCPLease)
+        .where(DHCPLease.subnet_id == subnet_id)
+        .order_by(DHCPLease.ip_address.asc())
+    )
+    return [DHCPLeaseResponse.model_validate(item) for item in result.scalars().all()]
+
+
+@router.get("/leases/active", response_model=List[DHCPLeaseResponse])
+async def list_active_leases(
+    user_id: int = Depends(require_auth),
+    db: AsyncSession = Depends(get_db),
+):
+    _ = user_id
+    result = await db.execute(
+        select(DHCPLease)
+        .where(DHCPLease.state == "active")
+        .order_by(DHCPLease.id.desc())
+    )
+    return [DHCPLeaseResponse.model_validate(item) for item in result.scalars().all()]
+
+
+@router.delete("/leases/{lease_id}", response_model=DHCPLeaseReleaseResponse)
+async def release_lease(
+    lease_id: int,
+    user_id: int = Depends(require_admin),
+    db: AsyncSession = Depends(get_db),
+):
+    result = await db.execute(select(DHCPLease).where(DHCPLease.id == lease_id))
+    lease = result.scalar_one_or_none()
+    if not lease:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="DHCP lease not found")
+
+    lease.state = "released"
+    now = datetime.utcnow()
+    lease.released_at = now
+    lease.lease_end = now
+
+    await db.commit()
+    subnet_result = await db.execute(select(DHCPSubnet).where(DHCPSubnet.id == lease.subnet_id))
+    subnet = subnet_result.scalar_one()
+    server_result = await db.execute(select(DHCPServer).where(DHCPServer.id == subnet.server_id))
+    server = server_result.scalar_one()
+    await log_audit(
+        db=db,
+        user_id=user_id,
+        action="update",
+        resource_type="dhcp_lease",
+        resource_id=lease.id,
+        instance_id=server.instance_id,
+        new_value={"state": "released"},
+    )
+    await db.refresh(lease)
+    return DHCPLeaseReleaseResponse(id=lease.id, state=lease.state, released_at=lease.released_at)

--- a/services/api-gateway/tests/test_dhcp.py
+++ b/services/api-gateway/tests/test_dhcp.py
@@ -1,0 +1,315 @@
+import pytest
+import pytest_asyncio
+from datetime import datetime, timedelta
+
+from httpx import AsyncClient
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+from main import app
+from shared.database import get_db
+from shared.models import Base, DHCPLease, Instance, User
+from shared.security import get_password_hash
+
+
+pytestmark = pytest.mark.asyncio
+
+TEST_DATABASE_URL = "sqlite+aiosqlite:///:memory:"
+test_engine = create_async_engine(TEST_DATABASE_URL, future=True)
+TestSessionLocal = async_sessionmaker(test_engine, class_=AsyncSession, expire_on_commit=False)
+
+
+async def override_get_db():
+    async with TestSessionLocal() as session:
+        yield session
+
+
+@pytest_asyncio.fixture(autouse=True)
+async def setup_database():
+    previous_override = app.dependency_overrides.get(get_db)
+    app.dependency_overrides[get_db] = override_get_db
+    async with test_engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    yield
+    async with test_engine.begin() as conn:
+        await conn.run_sync(Base.metadata.drop_all)
+    if previous_override is None:
+        app.dependency_overrides.pop(get_db, None)
+    else:
+        app.dependency_overrides[get_db] = previous_override
+
+
+@pytest_asyncio.fixture
+async def admin_user():
+    async with TestSessionLocal() as session:
+        user = User(
+            username="dhcpadmin",
+            email="dhcpadmin@example.com",
+            password_hash=get_password_hash("dhcpadminpass"),
+            auth_backend="local",
+            role="admin",
+            is_active=True,
+        )
+        session.add(user)
+        await session.commit()
+        await session.refresh(user)
+        yield user
+
+
+@pytest_asyncio.fixture
+async def readonly_user():
+    async with TestSessionLocal() as session:
+        user = User(
+            username="dhcpreader",
+            email="dhcpreader@example.com",
+            password_hash=get_password_hash("dhcpreaderpass"),
+            auth_backend="local",
+            role="readonly",
+            is_active=True,
+        )
+        session.add(user)
+        await session.commit()
+        await session.refresh(user)
+        yield user
+
+
+@pytest_asyncio.fixture
+async def instance():
+    async with TestSessionLocal() as session:
+        item = Instance(
+            name="dhcp-instance-1",
+            hostname="dhcp1.example.local",
+            api_endpoint="https://dhcp1.example.local",
+            api_key="dhcp-key-1",
+            status="active",
+            capabilities=["dhcp"],
+        )
+        session.add(item)
+        await session.commit()
+        await session.refresh(item)
+        yield item
+
+
+async def _login(client: AsyncClient, username: str, password: str) -> str:
+    response = await client.post(
+        "/api/v1/auth/login",
+        json={"username": username, "password": password},
+    )
+    assert response.status_code == 200
+    return response.json()["access_token"]
+
+
+class TestDHCPModule:
+    async def test_create_list_update_server_and_subnet_flow(
+        self, client: AsyncClient, admin_user, instance
+    ):
+        token = await _login(client, "dhcpadmin", "dhcpadminpass")
+        headers = {"Authorization": f"Bearer {token}"}
+
+        create_server = await client.post(
+            f"/api/v1/dhcp/servers/{instance.id}",
+            json={
+                "name": "kea-main",
+                "dhcpv4_enabled": True,
+                "dhcpv6_enabled": True,
+                "ha_enabled": False,
+            },
+            headers=headers,
+        )
+        assert create_server.status_code == 201
+        server_id = create_server.json()["id"]
+
+        list_servers = await client.get(f"/api/v1/dhcp/servers/{instance.id}", headers=headers)
+        assert list_servers.status_code == 200
+        assert len(list_servers.json()) == 1
+
+        update_server = await client.patch(
+            f"/api/v1/dhcp/servers/{server_id}",
+            json={"ha_enabled": True, "ha_peer_address": "10.0.0.2", "ha_mode": "hot-standby"},
+            headers=headers,
+        )
+        assert update_server.status_code == 200
+        assert update_server.json()["ha_enabled"] is True
+
+        start_server = await client.post(
+            f"/api/v1/dhcp/servers/{server_id}/actions/start", headers=headers
+        )
+        assert start_server.status_code == 200
+
+        create_subnet = await client.post(
+            f"/api/v1/dhcp/servers/{server_id}/subnets",
+            json={
+                "name": "lan-v4",
+                "subnet": "192.168.10.0/24",
+                "type": "v4",
+                "lease_time_min": 300,
+                "lease_time_default": 3600,
+                "lease_time_max": 7200,
+                "routers": ["192.168.10.1"],
+                "dns_servers": ["192.168.10.53"],
+            },
+            headers=headers,
+        )
+        assert create_subnet.status_code == 201
+        subnet_id = create_subnet.json()["id"]
+
+        create_pool = await client.post(
+            f"/api/v1/dhcp/subnets/{subnet_id}/pools",
+            json={
+                "start_address": "192.168.10.100",
+                "end_address": "192.168.10.200",
+                "type": "v4",
+            },
+            headers=headers,
+        )
+        assert create_pool.status_code == 201
+        pool_id = create_pool.json()["id"]
+
+        create_reservation = await client.post(
+            f"/api/v1/dhcp/subnets/{subnet_id}/reservations",
+            json={
+                "hostname": "printer-01",
+                "ip_address": "192.168.10.20",
+                "hw_address": "aa:bb:cc:dd:ee:ff",
+                "type": "v4",
+                "description": "Office printer",
+            },
+            headers=headers,
+        )
+        assert create_reservation.status_code == 201
+        reservation_id = create_reservation.json()["id"]
+
+        create_option = await client.post(
+            f"/api/v1/dhcp/subnets/{subnet_id}/options",
+            json={
+                "option_code": 66,
+                "option_name": "tftp-server-name",
+                "option_value": "192.168.10.2",
+                "type": "v4",
+            },
+            headers=headers,
+        )
+        assert create_option.status_code == 201
+        option_id = create_option.json()["id"]
+
+        list_subnets = await client.get(
+            f"/api/v1/dhcp/servers/{server_id}/subnets", headers=headers
+        )
+        assert list_subnets.status_code == 200
+        assert list_subnets.json()[0]["pools_count"] == 1
+        assert list_subnets.json()[0]["reservations_count"] == 1
+
+        list_pools = await client.get(f"/api/v1/dhcp/subnets/{subnet_id}/pools", headers=headers)
+        assert list_pools.status_code == 200
+        assert len(list_pools.json()) == 1
+
+        list_reservations = await client.get(
+            f"/api/v1/dhcp/subnets/{subnet_id}/reservations", headers=headers
+        )
+        assert list_reservations.status_code == 200
+        assert len(list_reservations.json()) == 1
+
+        list_options = await client.get(
+            f"/api/v1/dhcp/subnets/{subnet_id}/options", headers=headers
+        )
+        assert list_options.status_code == 200
+        assert len(list_options.json()) == 1
+
+        delete_option = await client.delete(f"/api/v1/dhcp/options/{option_id}", headers=headers)
+        assert delete_option.status_code == 204
+
+        delete_reservation = await client.delete(
+            f"/api/v1/dhcp/reservations/{reservation_id}", headers=headers
+        )
+        assert delete_reservation.status_code == 204
+
+        delete_pool = await client.delete(f"/api/v1/dhcp/pools/{pool_id}", headers=headers)
+        assert delete_pool.status_code == 204
+
+    async def test_readonly_cannot_create_dhcp_server(
+        self, client: AsyncClient, readonly_user, instance
+    ):
+        token = await _login(client, "dhcpreader", "dhcpreaderpass")
+        headers = {"Authorization": f"Bearer {token}"}
+
+        response = await client.post(
+            f"/api/v1/dhcp/servers/{instance.id}",
+            json={"name": "blocked-dhcp", "dhcpv4_enabled": True, "dhcpv6_enabled": False},
+            headers=headers,
+        )
+        assert response.status_code == 403
+
+    async def test_lease_listing_and_release(self, client: AsyncClient, admin_user, instance):
+        token = await _login(client, "dhcpadmin", "dhcpadminpass")
+        headers = {"Authorization": f"Bearer {token}"}
+
+        create_server = await client.post(
+            f"/api/v1/dhcp/servers/{instance.id}",
+            json={"name": "kea-leases", "dhcpv4_enabled": True, "dhcpv6_enabled": False},
+            headers=headers,
+        )
+        assert create_server.status_code == 201
+        server_id = create_server.json()["id"]
+
+        create_subnet = await client.post(
+            f"/api/v1/dhcp/servers/{server_id}/subnets",
+            json={
+                "name": "lease-subnet",
+                "subnet": "10.50.0.0/24",
+                "type": "v4",
+                "lease_time_min": 300,
+                "lease_time_default": 1200,
+                "lease_time_max": 3600,
+            },
+            headers=headers,
+        )
+        assert create_subnet.status_code == 201
+        subnet_id = create_subnet.json()["id"]
+
+        create_pool = await client.post(
+            f"/api/v1/dhcp/subnets/{subnet_id}/pools",
+            json={
+                "start_address": "10.50.0.100",
+                "end_address": "10.50.0.180",
+                "type": "v4",
+            },
+            headers=headers,
+        )
+        assert create_pool.status_code == 201
+        pool_id = create_pool.json()["id"]
+
+        now = datetime.utcnow()
+        async with TestSessionLocal() as session:
+            lease = DHCPLease(
+                subnet_id=subnet_id,
+                pool_id=pool_id,
+                ip_address="10.50.0.110",
+                hw_address="52:54:00:12:34:56",
+                hostname="test-client",
+                client_id="client-1",
+                lease_start=now,
+                lease_end=now + timedelta(hours=1),
+                state="active",
+            )
+            session.add(lease)
+            await session.commit()
+            await session.refresh(lease)
+            lease_id = lease.id
+
+        list_active = await client.get("/api/v1/dhcp/leases/active", headers=headers)
+        assert list_active.status_code == 200
+        assert len(list_active.json()) == 1
+        assert list_active.json()[0]["id"] == lease_id
+
+        subnet_leases = await client.get(f"/api/v1/dhcp/subnets/{subnet_id}/leases", headers=headers)
+        assert subnet_leases.status_code == 200
+        assert subnet_leases.json()[0]["state"] == "active"
+
+        release = await client.delete(f"/api/v1/dhcp/leases/{lease_id}", headers=headers)
+        assert release.status_code == 200
+        assert release.json()["state"] == "released"
+
+        async with TestSessionLocal() as session:
+            result = await session.execute(select(DHCPLease).where(DHCPLease.id == lease_id))
+            lease = result.scalar_one()
+            assert lease.state == "released"

--- a/shared/models.py
+++ b/shared/models.py
@@ -699,6 +699,173 @@ class LLMUseCaseConfig(Base):
 
 
 # ============================================================================
+# DHCP MODELS - Kea DHCPv4/DHCPv6 Management
+# ============================================================================
+
+
+class DHCPServer(Base):
+    """DHCP server configuration (Kea instance on a managed instance)."""
+
+    __tablename__ = "dhcp_servers"
+
+    id = Column(Integer, primary_key=True)
+    instance_id = Column(Integer, ForeignKey("instances.id"), nullable=False)
+
+    name = Column(String(100), nullable=False)
+    description = Column(Text)
+
+    enabled = Column(Boolean, default=True)
+    status = Column(String(20), default="stopped")  # running, stopped, error
+
+    kea_ctrl_agent_address = Column(String(255), default="127.0.0.1")
+    kea_ctrl_agent_port = Column(Integer, default=8000)
+
+    ha_enabled = Column(Boolean, default=False)
+    ha_mode = Column(String(20), default="hot-standby")  # hot-standby, load-balancing
+    ha_peer_address = Column(String(255))
+
+    dhcpv4_enabled = Column(Boolean, default=True)
+    dhcpv6_enabled = Column(Boolean, default=False)
+
+    created_by = Column(Integer, ForeignKey("users.id"))
+    created_at = Column(DateTime, default=datetime.utcnow)
+    updated_at = Column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
+
+    subnets = relationship(
+        "DHCPSubnet", back_populates="server", cascade="all, delete-orphan"
+    )
+
+
+class DHCPSubnet(Base):
+    """DHCP subnet definition for IPv4 or IPv6."""
+
+    __tablename__ = "dhcp_subnets"
+
+    id = Column(Integer, primary_key=True)
+    server_id = Column(Integer, ForeignKey("dhcp_servers.id"), nullable=False)
+
+    name = Column(String(100), nullable=False)
+    description = Column(Text)
+    subnet = Column(String(100), nullable=False)
+    type = Column(String(10), nullable=False)  # v4, v6
+
+    interface = Column(String(50))
+    relay_addresses = Column(JSON, default=list)
+
+    domain_name = Column(String(255))
+    dns_servers = Column(JSON, default=list)
+    ntp_servers = Column(JSON, default=list)
+    routers = Column(JSON, default=list)
+
+    lease_time_default = Column(Integer, default=3600)
+    lease_time_max = Column(Integer, default=7200)
+    lease_time_min = Column(Integer, default=300)
+
+    delegated_prefix_length = Column(Integer)
+
+    enabled = Column(Boolean, default=True)
+    created_at = Column(DateTime, default=datetime.utcnow)
+    updated_at = Column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
+
+    server = relationship("DHCPServer", back_populates="subnets")
+    pools = relationship(
+        "DHCPPool", back_populates="subnet_ref", cascade="all, delete-orphan"
+    )
+    reservations = relationship(
+        "DHCPReservation", back_populates="subnet_ref", cascade="all, delete-orphan"
+    )
+    options = relationship(
+        "DHCPOption", back_populates="subnet_ref", cascade="all, delete-orphan"
+    )
+    leases = relationship(
+        "DHCPLease", back_populates="subnet_ref", cascade="all, delete-orphan"
+    )
+
+
+class DHCPPool(Base):
+    """Dynamic allocation pool inside a DHCP subnet."""
+
+    __tablename__ = "dhcp_pools"
+
+    id = Column(Integer, primary_key=True)
+    subnet_id = Column(Integer, ForeignKey("dhcp_subnets.id"), nullable=False)
+
+    start_address = Column(String(45), nullable=False)
+    end_address = Column(String(45), nullable=False)
+    type = Column(String(10), nullable=False)  # v4, v6
+
+    enabled = Column(Boolean, default=True)
+    created_at = Column(DateTime, default=datetime.utcnow)
+    updated_at = Column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
+
+    subnet_ref = relationship("DHCPSubnet", back_populates="pools")
+
+
+class DHCPReservation(Base):
+    """Static DHCP reservation."""
+
+    __tablename__ = "dhcp_reservations"
+
+    id = Column(Integer, primary_key=True)
+    subnet_id = Column(Integer, ForeignKey("dhcp_subnets.id"), nullable=False)
+
+    hostname = Column(String(255))
+    ip_address = Column(String(45), nullable=False)
+    hw_address = Column(String(255), nullable=False)  # MAC for v4, DUID for v6
+    type = Column(String(10), nullable=False)  # v4, v6
+    description = Column(Text)
+
+    created_at = Column(DateTime, default=datetime.utcnow)
+    updated_at = Column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
+
+    subnet_ref = relationship("DHCPSubnet", back_populates="reservations")
+
+
+class DHCPOption(Base):
+    """Custom DHCP option attached to a subnet."""
+
+    __tablename__ = "dhcp_options"
+
+    id = Column(Integer, primary_key=True)
+    subnet_id = Column(Integer, ForeignKey("dhcp_subnets.id"), nullable=False)
+
+    option_code = Column(Integer, nullable=False)
+    option_name = Column(String(100), nullable=False)
+    option_value = Column(Text, nullable=False)
+    type = Column(String(10), nullable=False)  # v4, v6
+
+    created_at = Column(DateTime, default=datetime.utcnow)
+    updated_at = Column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
+
+    subnet_ref = relationship("DHCPSubnet", back_populates="options")
+
+
+class DHCPLease(Base):
+    """Lease state cache synchronized from Kea."""
+
+    __tablename__ = "dhcp_leases"
+
+    id = Column(Integer, primary_key=True)
+    subnet_id = Column(Integer, ForeignKey("dhcp_subnets.id"), nullable=False)
+    pool_id = Column(Integer, ForeignKey("dhcp_pools.id"))
+
+    ip_address = Column(String(45), nullable=False)
+    hw_address = Column(String(255))
+    hostname = Column(String(255))
+    client_id = Column(String(255))
+
+    lease_start = Column(DateTime)
+    lease_end = Column(DateTime)
+    released_at = Column(DateTime)
+    state = Column(String(20), default="active")  # active, expired, released
+
+    created_at = Column(DateTime, default=datetime.utcnow)
+    updated_at = Column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
+
+    subnet_ref = relationship("DHCPSubnet", back_populates="leases")
+
+
+# ============================================================================
 # DNS MODELS - BIND9 Server Management
 # ============================================================================
 

--- a/shared/schemas.py
+++ b/shared/schemas.py
@@ -1151,6 +1151,236 @@ class QoSApplyResponse(BaseModel):
 
 
 # ============================================================================
+# DHCP SCHEMAS - Kea DHCPv4/DHCPv6 Management
+# ============================================================================
+
+
+class DHCPSubnetType(str, Enum):
+    V4 = "v4"
+    V6 = "v6"
+
+
+class DHCPServerStatus(str, Enum):
+    RUNNING = "running"
+    STOPPED = "stopped"
+    ERROR = "error"
+
+
+class DHCPLeaseState(str, Enum):
+    ACTIVE = "active"
+    EXPIRED = "expired"
+    RELEASED = "released"
+
+
+class DHCPHAType(str, Enum):
+    HOT_STANDBY = "hot-standby"
+    LOAD_BALANCING = "load-balancing"
+
+
+class DHCPServerBase(BaseModel):
+    name: str = Field(..., min_length=1, max_length=100)
+    description: Optional[str] = None
+    enabled: bool = True
+    kea_ctrl_agent_address: str = Field(default="127.0.0.1", max_length=255)
+    kea_ctrl_agent_port: int = Field(default=8000, ge=1, le=65535)
+    ha_enabled: bool = False
+    ha_mode: DHCPHAType = DHCPHAType.HOT_STANDBY
+    ha_peer_address: Optional[str] = Field(default=None, max_length=255)
+    dhcpv4_enabled: bool = True
+    dhcpv6_enabled: bool = False
+
+
+class DHCPServerCreate(DHCPServerBase):
+    pass
+
+
+class DHCPServerUpdate(BaseModel):
+    name: Optional[str] = None
+    description: Optional[str] = None
+    enabled: Optional[bool] = None
+    kea_ctrl_agent_address: Optional[str] = None
+    kea_ctrl_agent_port: Optional[int] = Field(default=None, ge=1, le=65535)
+    ha_enabled: Optional[bool] = None
+    ha_mode: Optional[DHCPHAType] = None
+    ha_peer_address: Optional[str] = None
+    dhcpv4_enabled: Optional[bool] = None
+    dhcpv6_enabled: Optional[bool] = None
+
+
+class DHCPServerResponse(DHCPServerBase):
+    id: int
+    instance_id: int
+    status: DHCPServerStatus
+    created_by: Optional[int]
+    created_at: datetime
+    updated_at: datetime
+    subnets_count: int = 0
+
+    class Config:
+        from_attributes = True
+
+
+class DHCPSubnetBase(BaseModel):
+    name: str = Field(..., min_length=1, max_length=100)
+    description: Optional[str] = None
+    subnet: str = Field(..., min_length=3, max_length=100)
+    type: DHCPSubnetType
+    interface: Optional[str] = Field(default=None, max_length=50)
+    relay_addresses: List[str] = Field(default_factory=list)
+    domain_name: Optional[str] = Field(default=None, max_length=255)
+    dns_servers: List[str] = Field(default_factory=list)
+    ntp_servers: List[str] = Field(default_factory=list)
+    routers: List[str] = Field(default_factory=list)
+    lease_time_default: int = Field(default=3600, ge=60)
+    lease_time_max: int = Field(default=7200, ge=60)
+    lease_time_min: int = Field(default=300, ge=60)
+    delegated_prefix_length: Optional[int] = Field(default=None, ge=1, le=128)
+    enabled: bool = True
+
+
+class DHCPSubnetCreate(DHCPSubnetBase):
+    pass
+
+
+class DHCPSubnetUpdate(BaseModel):
+    name: Optional[str] = None
+    description: Optional[str] = None
+    subnet: Optional[str] = None
+    interface: Optional[str] = None
+    relay_addresses: Optional[List[str]] = None
+    domain_name: Optional[str] = None
+    dns_servers: Optional[List[str]] = None
+    ntp_servers: Optional[List[str]] = None
+    routers: Optional[List[str]] = None
+    lease_time_default: Optional[int] = Field(default=None, ge=60)
+    lease_time_max: Optional[int] = Field(default=None, ge=60)
+    lease_time_min: Optional[int] = Field(default=None, ge=60)
+    delegated_prefix_length: Optional[int] = Field(default=None, ge=1, le=128)
+    enabled: Optional[bool] = None
+
+
+class DHCPSubnetResponse(DHCPSubnetBase):
+    id: int
+    server_id: int
+    created_at: datetime
+    updated_at: datetime
+    pools_count: int = 0
+    reservations_count: int = 0
+    leases_count: int = 0
+
+    class Config:
+        from_attributes = True
+
+
+class DHCPPoolBase(BaseModel):
+    start_address: str = Field(..., min_length=2, max_length=45)
+    end_address: str = Field(..., min_length=2, max_length=45)
+    type: DHCPSubnetType
+    enabled: bool = True
+
+
+class DHCPPoolCreate(DHCPPoolBase):
+    pass
+
+
+class DHCPPoolUpdate(BaseModel):
+    start_address: Optional[str] = None
+    end_address: Optional[str] = None
+    enabled: Optional[bool] = None
+
+
+class DHCPPoolResponse(DHCPPoolBase):
+    id: int
+    subnet_id: int
+    created_at: datetime
+    updated_at: datetime
+
+    class Config:
+        from_attributes = True
+
+
+class DHCPReservationBase(BaseModel):
+    hostname: Optional[str] = Field(default=None, max_length=255)
+    ip_address: str = Field(..., min_length=2, max_length=45)
+    hw_address: str = Field(..., min_length=2, max_length=255)
+    type: DHCPSubnetType
+    description: Optional[str] = None
+
+
+class DHCPReservationCreate(DHCPReservationBase):
+    pass
+
+
+class DHCPReservationUpdate(BaseModel):
+    hostname: Optional[str] = None
+    ip_address: Optional[str] = None
+    hw_address: Optional[str] = None
+    description: Optional[str] = None
+
+
+class DHCPReservationResponse(DHCPReservationBase):
+    id: int
+    subnet_id: int
+    created_at: datetime
+    updated_at: datetime
+
+    class Config:
+        from_attributes = True
+
+
+class DHCPOptionBase(BaseModel):
+    option_code: int = Field(..., ge=1, le=65535)
+    option_name: str = Field(..., min_length=1, max_length=100)
+    option_value: str = Field(..., min_length=1)
+    type: DHCPSubnetType
+
+
+class DHCPOptionCreate(DHCPOptionBase):
+    pass
+
+
+class DHCPOptionUpdate(BaseModel):
+    option_code: Optional[int] = Field(default=None, ge=1, le=65535)
+    option_name: Optional[str] = None
+    option_value: Optional[str] = None
+
+
+class DHCPOptionResponse(DHCPOptionBase):
+    id: int
+    subnet_id: int
+    created_at: datetime
+    updated_at: datetime
+
+    class Config:
+        from_attributes = True
+
+
+class DHCPLeaseResponse(BaseModel):
+    id: int
+    subnet_id: int
+    pool_id: Optional[int]
+    ip_address: str
+    hw_address: Optional[str]
+    hostname: Optional[str]
+    client_id: Optional[str]
+    lease_start: Optional[datetime]
+    lease_end: Optional[datetime]
+    released_at: Optional[datetime]
+    state: DHCPLeaseState
+    created_at: datetime
+    updated_at: datetime
+
+    class Config:
+        from_attributes = True
+
+
+class DHCPLeaseReleaseResponse(BaseModel):
+    id: int
+    state: DHCPLeaseState
+    released_at: datetime
+
+
+# ============================================================================
 # DNS SCHEMAS - BIND9 Management
 # ============================================================================
 


### PR DESCRIPTION
## Summary
- add DHCP backend domain models and schemas for servers, subnets, pools, reservations, options, and lease state
- implement `/api/v1/dhcp` router with CRUD endpoints, server actions, active lease listing, and lease release support
- add Alembic migration and backend API tests covering RBAC, full CRUD flow, and lease release behavior

## Validation
- `python -m pytest services/api-gateway/tests -v --asyncio-mode=auto`