### PR TITLE
feat(dhcp): add SDK and CLI support for DHCP APIs

### DIFF
--- a/sdk/cli/tests/test_cli.py
+++ b/sdk/cli/tests/test_cli.py
@@ -218,3 +218,60 @@ class TestMetrics:
         result = runner.invoke(app, ["metrics", "overview"])
         assert result.exit_code == 0
         assert "total_instances" in result.output
+
+
+class TestDHCP:
+    def test_list_dhcp_servers(self, httpx_mock, monkeypatch):
+        monkeypatch.setenv("VISWALL_URL", "https://viswall.example.com")
+        monkeypatch.setenv("VISWALL_TOKEN", "token")
+
+        httpx_mock.add_response(
+            url="https://viswall.example.com/api/v1/dhcp/servers/1",
+            json=[{"id": 1, "name": "kea-main", "status": "running", "subnets_count": 2}],
+        )
+
+        result = runner.invoke(app, ["dhcp", "servers", "--instance-id", "1"])
+        assert result.exit_code == 0
+        assert "kea-main" in result.output
+
+    def test_create_dhcp_subnet(self, httpx_mock, monkeypatch):
+        monkeypatch.setenv("VISWALL_URL", "https://viswall.example.com")
+        monkeypatch.setenv("VISWALL_TOKEN", "token")
+
+        httpx_mock.add_response(
+            url="https://viswall.example.com/api/v1/dhcp/servers/2/subnets",
+            method="POST",
+            json={"id": 10, "name": "lan-v4", "subnet": "192.168.10.0/24", "type": "v4"},
+        )
+
+        result = runner.invoke(
+            app,
+            [
+                "dhcp",
+                "subnet-create",
+                "--server-id",
+                "2",
+                "--name",
+                "lan-v4",
+                "--subnet",
+                "192.168.10.0/24",
+                "--type",
+                "v4",
+            ],
+        )
+        assert result.exit_code == 0
+        assert "lan-v4" in result.output
+
+    def test_release_dhcp_lease(self, httpx_mock, monkeypatch):
+        monkeypatch.setenv("VISWALL_URL", "https://viswall.example.com")
+        monkeypatch.setenv("VISWALL_TOKEN", "token")
+
+        httpx_mock.add_response(
+            url="https://viswall.example.com/api/v1/dhcp/leases/55",
+            method="DELETE",
+            json={"id": 55, "state": "released"},
+        )
+
+        result = runner.invoke(app, ["dhcp", "lease-release", "55", "--yes"])
+        assert result.exit_code == 0
+        assert "released" in result.output

--- a/sdk/cli/viswall_cli/commands/__init__.py
+++ b/sdk/cli/viswall_cli/commands/__init__.py
@@ -2,5 +2,6 @@ from viswall_cli.commands.instances import app as instances_app
 from viswall_cli.commands.firewall import app as firewall_app
 from viswall_cli.commands.users import app as users_app
 from viswall_cli.commands.metrics import app as metrics_app
+from viswall_cli.commands.dhcp import app as dhcp_app
 
-__all__ = ["instances_app", "firewall_app", "users_app", "metrics_app"]
+__all__ = ["instances_app", "firewall_app", "users_app", "metrics_app", "dhcp_app"]

--- a/sdk/cli/viswall_cli/commands/dhcp.py
+++ b/sdk/cli/viswall_cli/commands/dhcp.py
@@ -1,0 +1,199 @@
+"""DHCP commands."""
+
+from typing import Optional
+
+import typer
+
+from viswall_cli.utils import get_client
+from viswall_cli.output import print_result, print_success, print_error
+from viswall.exceptions import ViswallAPIError
+
+app = typer.Typer(help="Manage DHCP servers, subnets, and leases")
+
+
+@app.command("servers")
+def list_servers(
+    instance_id: int = typer.Option(..., "--instance-id", "-i", help="Instance ID"),
+    url: Optional[str] = typer.Option(None, "--url", "-u"),
+    token: Optional[str] = typer.Option(None, "--token", "-t"),
+    format: str = typer.Option("table", "--format", "-f"),
+) -> None:
+    """List DHCP servers for an instance."""
+    client = get_client(url=url, token=token)
+    try:
+        servers = client.dhcp.list_servers(instance_id)
+        print_result(
+            servers,
+            format=format,
+            columns=[
+                "id",
+                "name",
+                "status",
+                "dhcpv4_enabled",
+                "dhcpv6_enabled",
+                "subnets_count",
+            ],
+        )
+    except ViswallAPIError as e:
+        print_error(str(e))
+        raise typer.Exit(1)
+
+
+@app.command("server-create")
+def create_server(
+    instance_id: int = typer.Option(..., "--instance-id", "-i", help="Instance ID"),
+    name: str = typer.Option(..., "--name", "-n", help="Server name"),
+    dhcpv4: bool = typer.Option(True, "--dhcpv4/--no-dhcpv4", help="Enable DHCPv4"),
+    dhcpv6: bool = typer.Option(False, "--dhcpv6/--no-dhcpv6", help="Enable DHCPv6"),
+    ha_enabled: bool = typer.Option(False, "--ha-enabled", help="Enable HA"),
+    ha_peer_address: Optional[str] = typer.Option(None, "--ha-peer-address", help="HA peer address"),
+    url: Optional[str] = typer.Option(None, "--url", "-u"),
+    token: Optional[str] = typer.Option(None, "--token", "-t"),
+    format: str = typer.Option("json", "--format", "-f"),
+) -> None:
+    """Create a DHCP server."""
+    client = get_client(url=url, token=token)
+    try:
+        server = client.dhcp.create_server(
+            instance_id,
+            name=name,
+            dhcpv4_enabled=dhcpv4,
+            dhcpv6_enabled=dhcpv6,
+            ha_enabled=ha_enabled,
+            ha_peer_address=ha_peer_address,
+        )
+        print_result(server, format=format)
+        print_success(f"DHCP server '{name}' created")
+    except ViswallAPIError as e:
+        print_error(str(e))
+        raise typer.Exit(1)
+
+
+@app.command("subnets")
+def list_subnets(
+    server_id: int = typer.Option(..., "--server-id", "-s", help="DHCP server ID"),
+    url: Optional[str] = typer.Option(None, "--url", "-u"),
+    token: Optional[str] = typer.Option(None, "--token", "-t"),
+    format: str = typer.Option("table", "--format", "-f"),
+) -> None:
+    """List DHCP subnets for a server."""
+    client = get_client(url=url, token=token)
+    try:
+        subnets = client.dhcp.list_subnets(server_id)
+        print_result(
+            subnets,
+            format=format,
+            columns=[
+                "id",
+                "name",
+                "subnet",
+                "type",
+                "pools_count",
+                "reservations_count",
+                "leases_count",
+            ],
+        )
+    except ViswallAPIError as e:
+        print_error(str(e))
+        raise typer.Exit(1)
+
+
+@app.command("subnet-create")
+def create_subnet(
+    server_id: int = typer.Option(..., "--server-id", "-s", help="DHCP server ID"),
+    name: str = typer.Option(..., "--name", "-n", help="Subnet name"),
+    subnet: str = typer.Option(..., "--subnet", help="CIDR subnet"),
+    type: str = typer.Option("v4", "--type", help="Subnet type: v4 or v6"),
+    lease_min: int = typer.Option(300, "--lease-min", help="Minimum lease time"),
+    lease_default: int = typer.Option(3600, "--lease-default", help="Default lease time"),
+    lease_max: int = typer.Option(7200, "--lease-max", help="Maximum lease time"),
+    routers: Optional[str] = typer.Option(None, "--routers", help="Comma-separated router IPs"),
+    dns_servers: Optional[str] = typer.Option(None, "--dns-servers", help="Comma-separated DNS server IPs"),
+    url: Optional[str] = typer.Option(None, "--url", "-u"),
+    token: Optional[str] = typer.Option(None, "--token", "-t"),
+    format: str = typer.Option("json", "--format", "-f"),
+) -> None:
+    """Create a DHCP subnet."""
+    client = get_client(url=url, token=token)
+    try:
+        subnet_data = client.dhcp.create_subnet(
+            server_id,
+            name=name,
+            subnet=subnet,
+            type=type,
+            lease_time_min=lease_min,
+            lease_time_default=lease_default,
+            lease_time_max=lease_max,
+            routers=[v.strip() for v in routers.split(",") if v.strip()] if routers else [],
+            dns_servers=[v.strip() for v in dns_servers.split(",") if v.strip()] if dns_servers else [],
+        )
+        print_result(subnet_data, format=format)
+        print_success(f"DHCP subnet '{name}' created")
+    except ViswallAPIError as e:
+        print_error(str(e))
+        raise typer.Exit(1)
+
+
+@app.command("leases")
+def list_leases(
+    subnet_id: int = typer.Option(..., "--subnet-id", help="Subnet ID"),
+    url: Optional[str] = typer.Option(None, "--url", "-u"),
+    token: Optional[str] = typer.Option(None, "--token", "-t"),
+    format: str = typer.Option("table", "--format", "-f"),
+) -> None:
+    """List leases for a subnet."""
+    client = get_client(url=url, token=token)
+    try:
+        leases = client.dhcp.list_subnet_leases(subnet_id)
+        print_result(
+            leases,
+            format=format,
+            columns=["id", "ip_address", "state", "hostname", "hw_address", "lease_end"],
+        )
+    except ViswallAPIError as e:
+        print_error(str(e))
+        raise typer.Exit(1)
+
+
+@app.command("leases-active")
+def list_active_leases(
+    url: Optional[str] = typer.Option(None, "--url", "-u"),
+    token: Optional[str] = typer.Option(None, "--token", "-t"),
+    format: str = typer.Option("table", "--format", "-f"),
+) -> None:
+    """List active leases across all subnets."""
+    client = get_client(url=url, token=token)
+    try:
+        leases = client.dhcp.list_active_leases()
+        print_result(
+            leases,
+            format=format,
+            columns=["id", "subnet_id", "ip_address", "state", "hostname", "lease_end"],
+        )
+    except ViswallAPIError as e:
+        print_error(str(e))
+        raise typer.Exit(1)
+
+
+@app.command("lease-release")
+def release_lease(
+    lease_id: int = typer.Argument(..., help="Lease ID"),
+    yes: bool = typer.Option(False, "--yes", "-y", help="Skip confirmation"),
+    url: Optional[str] = typer.Option(None, "--url", "-u"),
+    token: Optional[str] = typer.Option(None, "--token", "-t"),
+    format: str = typer.Option("json", "--format", "-f"),
+) -> None:
+    """Release a lease by ID."""
+    if not yes:
+        confirm = typer.confirm(f"Release lease {lease_id}?")
+        if not confirm:
+            raise typer.Abort()
+
+    client = get_client(url=url, token=token)
+    try:
+        result = client.dhcp.release_lease(lease_id)
+        print_result(result, format=format)
+        print_success(f"Lease {lease_id} released")
+    except ViswallAPIError as e:
+        print_error(str(e))
+        raise typer.Exit(1)

--- a/sdk/cli/viswall_cli/main.py
+++ b/sdk/cli/viswall_cli/main.py
@@ -11,7 +11,7 @@ from viswall.exceptions import AuthenticationError, ViswallAPIError
 
 from viswall_cli.config import Config, DEFAULT_CONFIG_FILE
 from viswall_cli.output import print_error, print_success
-from viswall_cli.commands import instances_app, firewall_app, users_app, metrics_app
+from viswall_cli.commands import instances_app, firewall_app, users_app, metrics_app, dhcp_app
 
 app = typer.Typer(
     name="viswall",
@@ -74,6 +74,7 @@ app.add_typer(instances_app, name="instances")
 app.add_typer(firewall_app, name="firewall")
 app.add_typer(users_app, name="users")
 app.add_typer(metrics_app, name="metrics")
+app.add_typer(dhcp_app, name="dhcp")
 
 
 @app.callback()

--- a/sdk/python/tests/test_client.py
+++ b/sdk/python/tests/test_client.py
@@ -184,3 +184,56 @@ class TestMailResource:
         result = client.mail.list_users(domain_id=5)
         assert len(result) == 1
         client.close()
+
+
+class TestDHCPResource:
+    """Test DHCPResource."""
+
+    def test_list_servers(self, httpx_mock):
+        """Test list DHCP servers."""
+        httpx_mock.add_response(
+            url="https://test.example.com/api/v1/dhcp/servers/1",
+            method="GET",
+            json=[{"id": 1, "name": "kea-main"}],
+        )
+
+        client = ViswallClient(base_url="https://test.example.com", token="jwt")
+        result = client.dhcp.list_servers(instance_id=1)
+        assert len(result) == 1
+        assert result[0]["name"] == "kea-main"
+        client.close()
+
+    def test_create_subnet(self, httpx_mock):
+        """Test create DHCP subnet."""
+        httpx_mock.add_response(
+            url="https://test.example.com/api/v1/dhcp/servers/1/subnets",
+            method="POST",
+            status_code=201,
+            json={"id": 11, "name": "lan-v4", "subnet": "192.168.10.0/24", "type": "v4"},
+        )
+
+        client = ViswallClient(base_url="https://test.example.com", token="jwt")
+        result = client.dhcp.create_subnet(
+            server_id=1,
+            name="lan-v4",
+            subnet="192.168.10.0/24",
+            type="v4",
+            lease_time_min=300,
+            lease_time_default=3600,
+            lease_time_max=7200,
+        )
+        assert result["id"] == 11
+        client.close()
+
+    def test_release_lease(self, httpx_mock):
+        """Test release DHCP lease."""
+        httpx_mock.add_response(
+            url="https://test.example.com/api/v1/dhcp/leases/99",
+            method="DELETE",
+            json={"id": 99, "state": "released", "released_at": "2026-01-01T00:00:00Z"},
+        )
+
+        client = ViswallClient(base_url="https://test.example.com", token="jwt")
+        result = client.dhcp.release_lease(lease_id=99)
+        assert result["state"] == "released"
+        client.close()

--- a/sdk/python/viswall/client.py
+++ b/sdk/python/viswall/client.py
@@ -23,6 +23,7 @@ from viswall.resources import (
     VPNResource,
     AssistantResource,
     GroupwareResource,
+    DHCPResource,
 )
 
 T = TypeVar("T")
@@ -88,6 +89,7 @@ class ViswallClient:
         self.vpn = VPNResource(self)
         self.assistant = AssistantResource(self)
         self.groupware = GroupwareResource(self)
+        self.dhcp = DHCPResource(self)
 
     def _request(
         self,

--- a/sdk/python/viswall/resources/__init__.py
+++ b/sdk/python/viswall/resources/__init__.py
@@ -11,6 +11,7 @@ from viswall.resources.audit import AuditResource
 from viswall.resources.vpn import VPNResource
 from viswall.resources.assistant import AssistantResource
 from viswall.resources.groupware import GroupwareResource
+from viswall.resources.dhcp import DHCPResource
 
 __all__ = [
     "AuthResource",
@@ -24,4 +25,5 @@ __all__ = [
     "VPNResource",
     "AssistantResource",
     "GroupwareResource",
+    "DHCPResource",
 ]

--- a/sdk/python/viswall/resources/dhcp.py
+++ b/sdk/python/viswall/resources/dhcp.py
@@ -1,0 +1,107 @@
+"""DHCP resource."""
+
+from typing import TYPE_CHECKING, Dict, Any, List
+
+if TYPE_CHECKING:
+    from viswall.client import ViswallClient
+
+
+class DHCPResource:
+    """DHCP server, subnet, and lease operations."""
+
+    def __init__(self, client: "ViswallClient"):
+        self._client = client
+
+    def list_servers(self, instance_id: int) -> List[Dict[str, Any]]:
+        """List DHCP servers for an instance."""
+        return self._client._request("GET", f"/dhcp/servers/{instance_id}")
+
+    def create_server(self, instance_id: int, **kwargs: Any) -> Dict[str, Any]:
+        """Create a DHCP server."""
+        return self._client._request("POST", f"/dhcp/servers/{instance_id}", json=kwargs)
+
+    def get_server(self, server_id: int) -> Dict[str, Any]:
+        """Get DHCP server details by ID."""
+        return self._client._request("GET", f"/dhcp/servers/detail/{server_id}")
+
+    def update_server(self, server_id: int, **kwargs: Any) -> Dict[str, Any]:
+        """Update DHCP server."""
+        return self._client._request("PATCH", f"/dhcp/servers/{server_id}", json=kwargs)
+
+    def delete_server(self, server_id: int) -> None:
+        """Delete DHCP server."""
+        self._client._request("DELETE", f"/dhcp/servers/{server_id}")
+
+    def server_action(self, server_id: int, action: str) -> Dict[str, Any]:
+        """Run DHCP server action: start, stop, reload."""
+        return self._client._request("POST", f"/dhcp/servers/{server_id}/actions/{action}")
+
+    def list_subnets(self, server_id: int) -> List[Dict[str, Any]]:
+        """List DHCP subnets for a server."""
+        return self._client._request("GET", f"/dhcp/servers/{server_id}/subnets")
+
+    def create_subnet(self, server_id: int, **kwargs: Any) -> Dict[str, Any]:
+        """Create a DHCP subnet on a server."""
+        return self._client._request("POST", f"/dhcp/servers/{server_id}/subnets", json=kwargs)
+
+    def get_subnet(self, subnet_id: int) -> Dict[str, Any]:
+        """Get DHCP subnet details."""
+        return self._client._request("GET", f"/dhcp/subnets/detail/{subnet_id}")
+
+    def update_subnet(self, subnet_id: int, **kwargs: Any) -> Dict[str, Any]:
+        """Update DHCP subnet."""
+        return self._client._request("PATCH", f"/dhcp/subnets/{subnet_id}", json=kwargs)
+
+    def delete_subnet(self, subnet_id: int) -> None:
+        """Delete DHCP subnet."""
+        self._client._request("DELETE", f"/dhcp/subnets/{subnet_id}")
+
+    def list_pools(self, subnet_id: int) -> List[Dict[str, Any]]:
+        """List DHCP pools for a subnet."""
+        return self._client._request("GET", f"/dhcp/subnets/{subnet_id}/pools")
+
+    def create_pool(self, subnet_id: int, **kwargs: Any) -> Dict[str, Any]:
+        """Create a DHCP pool."""
+        return self._client._request("POST", f"/dhcp/subnets/{subnet_id}/pools", json=kwargs)
+
+    def delete_pool(self, pool_id: int) -> None:
+        """Delete DHCP pool."""
+        self._client._request("DELETE", f"/dhcp/pools/{pool_id}")
+
+    def list_reservations(self, subnet_id: int) -> List[Dict[str, Any]]:
+        """List DHCP reservations for a subnet."""
+        return self._client._request("GET", f"/dhcp/subnets/{subnet_id}/reservations")
+
+    def create_reservation(self, subnet_id: int, **kwargs: Any) -> Dict[str, Any]:
+        """Create a DHCP reservation."""
+        return self._client._request(
+            "POST", f"/dhcp/subnets/{subnet_id}/reservations", json=kwargs
+        )
+
+    def delete_reservation(self, reservation_id: int) -> None:
+        """Delete DHCP reservation."""
+        self._client._request("DELETE", f"/dhcp/reservations/{reservation_id}")
+
+    def list_options(self, subnet_id: int) -> List[Dict[str, Any]]:
+        """List DHCP options for a subnet."""
+        return self._client._request("GET", f"/dhcp/subnets/{subnet_id}/options")
+
+    def create_option(self, subnet_id: int, **kwargs: Any) -> Dict[str, Any]:
+        """Create a DHCP option."""
+        return self._client._request("POST", f"/dhcp/subnets/{subnet_id}/options", json=kwargs)
+
+    def delete_option(self, option_id: int) -> None:
+        """Delete DHCP option."""
+        self._client._request("DELETE", f"/dhcp/options/{option_id}")
+
+    def list_subnet_leases(self, subnet_id: int) -> List[Dict[str, Any]]:
+        """List DHCP leases for a subnet."""
+        return self._client._request("GET", f"/dhcp/subnets/{subnet_id}/leases")
+
+    def list_active_leases(self) -> List[Dict[str, Any]]:
+        """List all active DHCP leases."""
+        return self._client._request("GET", "/dhcp/leases/active")
+
+    def release_lease(self, lease_id: int) -> Dict[str, Any]:
+        """Release a DHCP lease."""
+        return self._client._request("DELETE", f"/dhcp/leases/{lease_id}")

--- a/sdk/typescript/src/client.ts
+++ b/sdk/typescript/src/client.ts
@@ -19,6 +19,7 @@ import {
   VPNResource,
   AssistantResource,
   GroupwareResource,
+  DHCPResource,
 } from './resources';
 
 export interface ViswallClientConfig {
@@ -41,6 +42,7 @@ export class ViswallClient {
   public readonly vpn: VPNResource;
   public readonly assistant: AssistantResource;
   public readonly groupware: GroupwareResource;
+  public readonly dhcp: DHCPResource;
 
   constructor(config: ViswallClientConfig) {
     const baseURL = config.baseURL.replace(/\/$/, '') + '/api/v1';
@@ -79,6 +81,7 @@ export class ViswallClient {
     this.vpn = new VPNResource(this);
     this.assistant = new AssistantResource(this);
     this.groupware = new GroupwareResource(this);
+    this.dhcp = new DHCPResource(this);
   }
 
   async request<T = unknown>(

--- a/sdk/typescript/src/index.ts
+++ b/sdk/typescript/src/index.ts
@@ -19,4 +19,5 @@ export {
   VPNResource,
   AssistantResource,
   GroupwareResource,
+  DHCPResource,
 } from './resources';

--- a/sdk/typescript/src/resources/dhcp.ts
+++ b/sdk/typescript/src/resources/dhcp.ts
@@ -1,0 +1,121 @@
+import { ViswallClient } from '../client';
+
+export class DHCPResource {
+  constructor(private readonly client: ViswallClient) {}
+
+  async listServers(instanceId: number): Promise<unknown[]> {
+    return this.client.request('GET', `/dhcp/servers/${instanceId}`);
+  }
+
+  async createServer(
+    instanceId: number,
+    data: Record<string, unknown>,
+  ): Promise<Record<string, unknown>> {
+    return this.client.request('POST', `/dhcp/servers/${instanceId}`, { data });
+  }
+
+  async getServer(serverId: number): Promise<Record<string, unknown>> {
+    return this.client.request('GET', `/dhcp/servers/detail/${serverId}`);
+  }
+
+  async updateServer(
+    serverId: number,
+    data: Record<string, unknown>,
+  ): Promise<Record<string, unknown>> {
+    return this.client.request('PATCH', `/dhcp/servers/${serverId}`, { data });
+  }
+
+  async deleteServer(serverId: number): Promise<void> {
+    return this.client.request('DELETE', `/dhcp/servers/${serverId}`);
+  }
+
+  async serverAction(
+    serverId: number,
+    action: 'start' | 'stop' | 'reload',
+  ): Promise<Record<string, unknown>> {
+    return this.client.request('POST', `/dhcp/servers/${serverId}/actions/${action}`);
+  }
+
+  async listSubnets(serverId: number): Promise<unknown[]> {
+    return this.client.request('GET', `/dhcp/servers/${serverId}/subnets`);
+  }
+
+  async createSubnet(
+    serverId: number,
+    data: Record<string, unknown>,
+  ): Promise<Record<string, unknown>> {
+    return this.client.request('POST', `/dhcp/servers/${serverId}/subnets`, { data });
+  }
+
+  async getSubnet(subnetId: number): Promise<Record<string, unknown>> {
+    return this.client.request('GET', `/dhcp/subnets/detail/${subnetId}`);
+  }
+
+  async updateSubnet(
+    subnetId: number,
+    data: Record<string, unknown>,
+  ): Promise<Record<string, unknown>> {
+    return this.client.request('PATCH', `/dhcp/subnets/${subnetId}`, { data });
+  }
+
+  async deleteSubnet(subnetId: number): Promise<void> {
+    return this.client.request('DELETE', `/dhcp/subnets/${subnetId}`);
+  }
+
+  async listPools(subnetId: number): Promise<unknown[]> {
+    return this.client.request('GET', `/dhcp/subnets/${subnetId}/pools`);
+  }
+
+  async createPool(
+    subnetId: number,
+    data: Record<string, unknown>,
+  ): Promise<Record<string, unknown>> {
+    return this.client.request('POST', `/dhcp/subnets/${subnetId}/pools`, { data });
+  }
+
+  async deletePool(poolId: number): Promise<void> {
+    return this.client.request('DELETE', `/dhcp/pools/${poolId}`);
+  }
+
+  async listReservations(subnetId: number): Promise<unknown[]> {
+    return this.client.request('GET', `/dhcp/subnets/${subnetId}/reservations`);
+  }
+
+  async createReservation(
+    subnetId: number,
+    data: Record<string, unknown>,
+  ): Promise<Record<string, unknown>> {
+    return this.client.request('POST', `/dhcp/subnets/${subnetId}/reservations`, { data });
+  }
+
+  async deleteReservation(reservationId: number): Promise<void> {
+    return this.client.request('DELETE', `/dhcp/reservations/${reservationId}`);
+  }
+
+  async listOptions(subnetId: number): Promise<unknown[]> {
+    return this.client.request('GET', `/dhcp/subnets/${subnetId}/options`);
+  }
+
+  async createOption(
+    subnetId: number,
+    data: Record<string, unknown>,
+  ): Promise<Record<string, unknown>> {
+    return this.client.request('POST', `/dhcp/subnets/${subnetId}/options`, { data });
+  }
+
+  async deleteOption(optionId: number): Promise<void> {
+    return this.client.request('DELETE', `/dhcp/options/${optionId}`);
+  }
+
+  async listSubnetLeases(subnetId: number): Promise<unknown[]> {
+    return this.client.request('GET', `/dhcp/subnets/${subnetId}/leases`);
+  }
+
+  async listActiveLeases(): Promise<unknown[]> {
+    return this.client.request('GET', '/dhcp/leases/active');
+  }
+
+  async releaseLease(leaseId: number): Promise<Record<string, unknown>> {
+    return this.client.request('DELETE', `/dhcp/leases/${leaseId}`);
+  }
+}

--- a/sdk/typescript/src/resources/index.ts
+++ b/sdk/typescript/src/resources/index.ts
@@ -9,3 +9,4 @@ export { AuditResource } from './audit';
 export { VPNResource } from './vpn';
 export { AssistantResource } from './assistant';
 export { GroupwareResource } from './groupware';
+export { DHCPResource } from './dhcp';

--- a/sdk/typescript/tests/client.test.ts
+++ b/sdk/typescript/tests/client.test.ts
@@ -26,6 +26,7 @@ describe('ViswallClient', () => {
     expect(client.auth).toBeDefined();
     expect(client.instances).toBeDefined();
     expect(client.firewall).toBeDefined();
+    expect(client.dhcp).toBeDefined();
   });
 
   it('should set and clear token', () => {
@@ -115,6 +116,46 @@ describe('ViswallClient', () => {
         action: 'accept',
       });
       expect(result).toHaveProperty('name', 'allow-https');
+    });
+  });
+
+  describe('DHCPResource', () => {
+    it('should list DHCP servers', async () => {
+      server.use(
+        http.get('https://viswall.example.com/api/v1/dhcp/servers/1', () => {
+          return HttpResponse.json([{ id: 1, name: 'kea-main' }]);
+        }),
+      );
+
+      const result = await client.dhcp.listServers(1);
+      expect(Array.isArray(result)).toBe(true);
+      expect(result).toHaveLength(1);
+    });
+
+    it('should create DHCP subnet', async () => {
+      server.use(
+        http.post('https://viswall.example.com/api/v1/dhcp/servers/1/subnets', () => {
+          return HttpResponse.json({ id: 10, name: 'lan-v4', type: 'v4' });
+        }),
+      );
+
+      const result = await client.dhcp.createSubnet(1, {
+        name: 'lan-v4',
+        subnet: '192.168.10.0/24',
+        type: 'v4',
+      });
+      expect(result).toHaveProperty('id', 10);
+    });
+
+    it('should release DHCP lease', async () => {
+      server.use(
+        http.delete('https://viswall.example.com/api/v1/dhcp/leases/44', () => {
+          return HttpResponse.json({ id: 44, state: 'released' });
+        }),
+      );
+
+      const result = await client.dhcp.releaseLease(44);
+      expect(result).toHaveProperty('state', 'released');
     });
   });
 


### PR DESCRIPTION
## Summary
- add a new DHCP resource to the Python SDK and TypeScript SDK, covering server/subnet/pool/reservation/option/lease operations
- expose DHCP operations in the CLI via a new `viswall dhcp` command group (servers, subnet creation/listing, lease listing, lease release)
- extend SDK and CLI test suites to validate DHCP endpoint integration and command behavior

## Validation
- `cd sdk/python && python -m pytest tests/ -v && python -m ruff check viswall/ && python -m mypy viswall/`
- `cd sdk/typescript && npm run type-check && npm run test`
- `cd sdk/cli && python -m pytest tests/ -v && python -m ruff check viswall_cli/ && python -m mypy viswall_cli/`