### PR TITLE
🧹 Remove unused sessionmaker imports

### DIFF
--- a/services/api-gateway/tests/test_auth.py
+++ b/services/api-gateway/tests/test_auth.py
@@ -4,7 +4,6 @@ import pytest
 import pytest_asyncio
 from httpx import AsyncClient
 from sqlalchemy.ext.asyncio import create_async_engine, AsyncSession, async_sessionmaker
-from sqlalchemy.orm import sessionmaker
 
 from shared.database import get_db
 from shared.models import Base, User

--- a/shared/database.py
+++ b/shared/database.py
@@ -1,5 +1,4 @@
 from sqlalchemy.ext.asyncio import create_async_engine, AsyncSession, async_sessionmaker
-from sqlalchemy.orm import sessionmaker
 import os
 
 DATABASE_URL = os.getenv(


### PR DESCRIPTION
🎯 **What:** Removed unused `sessionmaker` imports from `shared/database.py` and `services/api-gateway/tests/test_auth.py`.
💡 **Why:** `async_sessionmaker` is used, so the synchronous `sessionmaker` import is unused and unnecessary.
✅ **Verification:** Ran test suite to verify no regressions were introduced.
✨ **Result:** Improved code cleanliness and readability without affecting functionality.

---
*PR created automatically by Jules for task [17062457371247020909](https://jules.google.com/task/17062457371247020909) started by @hrohrweck*